### PR TITLE
fix/react warning

### DIFF
--- a/__tests__/HasuraCrud.test.tsx
+++ b/__tests__/HasuraCrud.test.tsx
@@ -9,7 +9,7 @@ import 'setimmediate';
 import HasuraCRUD from '../pages/hasura-crud';
 import { MockedProvider } from '@apollo/client/testing';
 import { GET_USERS } from '../queries/queries';
-import { act } from 'react-dom/test-utils';
+import { act } from 'react';
 
 process.env.NEXT_PUBLIC_HASURA_URL =
   'https://kakikubo-hasura.hasura.app/v1/graphql';

--- a/__tests__/NavBar.test.tsx
+++ b/__tests__/NavBar.test.tsx
@@ -46,16 +46,14 @@ describe('Navigation Test Cases', () => {
     userEvent.click(screen.getByTestId('makevar-nav'));
     expect(await screen.findByText('makeVar')).toBeInTheDocument();
     userEvent.click(screen.getByTestId('fetchpolicy-nav'));
-    console.log(screen.debug()); // クリック後のページ内容をログに出力
+    // console.log(screen.debug()); // クリック後のページ内容をログに出力
     expect(await screen.findByText('fetchPolicy(Hasura)')).toBeInTheDocument();
     userEvent.click(screen.getByTestId('crud-nav'));
     expect(await screen.findByText('CRUD(Hasura)')).toBeInTheDocument();
     userEvent.click(screen.getByTestId('ssg-nav'));
     expect(await screen.findByText('SSG+ISR(Hasura)')).toBeInTheDocument();
     userEvent.click(screen.getByTestId('memo-nav'));
-    expect(
-      await screen.findByText('custom hook + memo')
-    ).toBeInTheDocument();
+    expect(await screen.findByText('custom hook + memo')).toBeInTheDocument();
     userEvent.click(screen.getByTestId('home-nav'));
     expect(await screen.findByText('Next.js + GraphQL')).toBeInTheDocument();
   });

--- a/components/Layout.tsx
+++ b/components/Layout.tsx
@@ -2,6 +2,7 @@ import { ReactNode, FC } from 'react';
 import Head from 'next/head';
 import Link from 'next/link';
 import Image from 'next/image';
+import { LinkComponent } from './LinkComponent';
 
 interface Props {
   children: ReactNode;
@@ -21,54 +22,54 @@ export const Layout: FC<Props> = ({
         <nav className="bg-gray-800 w-screen">
           <div className="flex item-center pl-8 h-14">
             <div className="flex space-x-4">
-              <Link href="/">
-                <a
+              <LinkComponent href="/">
+                <span
                   data-testid="home-nav"
                   className="text-gray-300 hover:bg-gray-700 px-3 py-2 rounded"
                 >
                   Home
-                </a>
-              </Link>
-              <Link href="/local-state-a">
-                <a
+                </span>
+              </LinkComponent>
+              <LinkComponent href="/local-state-a">
+                <span
                   data-testid="makevar-nav"
                   className="text-gray-300 hover:bg-gray-700 px-3 py-2 rounded"
                 >
                   makeVar
-                </a>
-              </Link>
-              <Link href="/hasura-main">
-                <a
+                </span>
+              </LinkComponent>
+              <LinkComponent href="/hasura-main">
+                <span
                   data-testid="fetchpolicy-nav"
                   className="text-gray-300 hover:bg-gray-700 px-3 py-2 rounded"
                 >
                   fetchPolicy(Hasura)
-                </a>
-              </Link>
-              <Link href="/hasura-crud">
-                <a
+                </span>
+              </LinkComponent>
+              <LinkComponent href="/hasura-crud">
+                <span
                   data-testid="crud-nav"
                   className="text-gray-300 hover:bg-gray-700 px-3 py-2 rounded"
                 >
                   CRUD(Hasura)
-                </a>
-              </Link>
-              <Link href="/hasura-ssg">
-                <a
+                </span>
+              </LinkComponent>
+              <LinkComponent href="/hasura-ssg">
+                <span
                   data-testid="ssg-nav"
                   className="text-gray-300 hover:bg-gray-700 px-3 py-2 rounded"
                 >
                   SSG+ISR(Hasura)
-                </a>
-              </Link>
-              <Link href="/hooks-memo">
-                <a
+                </span>
+              </LinkComponent>
+              <LinkComponent href="/hooks-memo">
+                <span
                   data-testid="memo-nav"
                   className="text-gray-300 hover:bg-gray-700 px-3 py-2 rounded"
                 >
                   custom hook + memo
-                </a>
-              </Link>
+                </span>
+              </LinkComponent>
             </div>
           </div>
         </nav>

--- a/components/LinkComponent.tsx
+++ b/components/LinkComponent.tsx
@@ -1,0 +1,15 @@
+import Link from 'next/link';
+
+export const LinkComponent = ({
+  children,
+  href,
+}: {
+  children: React.ReactNode;
+  href: string;
+}) => {
+  return (
+    <Link href={href} legacyBehavior={false}>
+      {children}
+    </Link>
+  );
+};

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "@graphql-codegen/typescript": "^4.0.6",
     "@graphql-codegen/typescript-operations": "^4.2.0",
     "@graphql-codegen/typescript-react-apollo": "^4.3.0",
+    "@mswjs/interceptors": "^0.26.5",
     "@testing-library/dom": "^10.0.0",
     "@testing-library/jest-dom": "^6.4.2",
     "@testing-library/react": "^16.0.0",
@@ -45,6 +46,7 @@
     "@types/react": "^19.0.8",
     "@types/react-dom": "^19.0.0",
     "babel-jest": "^29.3.1",
+    "cross-fetch": "^4.0.0",
     "eslint": "^9.1.0",
     "eslint-config-next": "^15.1.5",
     "jest": "^29.7.0",
@@ -54,9 +56,12 @@
     "ts-jest": "^29.1.3",
     "ts-node": "^10.9.2",
     "typescript": "^5.6.2",
-    "cross-fetch": "^4.0.0",
-    "@mswjs/interceptors": "^0.26.5",
     "util": "^0.12.5",
     "web-streams-polyfill": "^4.0.0"
+  },
+  "pnpm": {
+    "onlyBuiltDependencies": [
+      "msw"
+    ]
   }
 }

--- a/pages/hasura-main.tsx
+++ b/pages/hasura-main.tsx
@@ -4,6 +4,7 @@ import { useQuery } from '@apollo/client';
 import { GET_USERS } from '../queries/queries';
 import { GetUsersQuery, Users_Constraint } from '../types/generated/graphql';
 import { Layout } from '../components/Layout';
+import { LinkComponent } from '../components/LinkComponent';
 
 const FetchMain: FC = () => {
   const { data, error } = useQuery<GetUsersQuery>(GET_USERS, {
@@ -30,9 +31,9 @@ const FetchMain: FC = () => {
           </p>
         );
       })}
-      <Link href="/hasura-sub">
-        <a className="mt-6">Next</a>
-      </Link>
+      <LinkComponent href="/hasura-sub">
+        <span className="mt-6">Next</span>
+      </LinkComponent>
     </Layout>
   );
 };


### PR DESCRIPTION
- **Warningの対処:     `ReactDOMTestUtils.act` is deprecated in favor of `React.act`. Import `act` from `react` instead of `react-dom/test-utils`. See https://react.dev/warnings/react-dom-test-utils for more info.**
  

- **pnpm approve-builds**
  ✔ Choose which packages to build (Press <space> to select, <a> to toggle
  all, <i> to invert selection) · msw
  ✔ The next packages will now be built: msw.
  Do you approve? (y/N) · true
  node_modules/.pnpm/msw@2.7.3_@types+node@22.13.5_typescript@5.7.3/node_modules/msw:
  Running postinstall script, done in 125ms
  

- **LinkComponentを用いてWarningを解消**
  

- **consoleエラーの対処**
  

- **console.logの出力を抑制**
  