### PR TITLE
nodejs20.xのどこかのバージョンから、`openssl-legacy-provider`オプションをつけなくとも正常に起動するようになったので削除

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,10 +3,10 @@
   "packageManager": "pnpm@10.14.0",
   "private": true,
   "engines": {
-    "node": ">=20.9.0"
+    "node": ">=20.12.2"
   },
   "scripts": {
-    "dev": "export NODE_OPTIONS=--openssl-legacy-provider && next dev",
+    "dev": "next dev",
     "build": "next build",
     "start": "next start",
     "lint": "next lint",


### PR DESCRIPTION


以前は以下のように、エラーが発生していた。
```
error:0308010C:digital envelope routines::unsupported

```