### PR TITLE
TypeScript moduleResolution非推奨警告の修正

### DIFF
--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/dev/types/routes.d.ts";
+import "./.next/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/pages/api-reference/config/typescript for more information.

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,7 +11,7 @@
     "esModuleInterop": true,
     "allowSyntheticDefaultImports": true,
     "module": "esnext",
-    "moduleResolution": "node",
+    "moduleResolution": "bundler",
     "resolveJsonModule": true,
     "isolatedModules": true,
     "jsx": "react-jsx",


### PR DESCRIPTION
## 概要
TypeScript 7.0で削除予定の`moduleResolution: "node"`の非推奨警告を修正しました。

## 問題
```
オプション 'moduleResolution=node10' は非推奨であり、TypeScript 7.0 で機能しなくなります。
compilerOption '"ignoreDeprecations": "6.0"' を指定して、このエラーを無音にします。
移行情報については、http://aka.ms/ts6 にアクセスしてください。
```

## 修正内容
- ✅ `tsconfig.json`で`moduleResolution`を`"node"`から`"bundler"`に変更
- ✅ Next.jsプロジェクトに最適化された設定に更新
- ✅ TypeScript 7.0の非推奨警告を解消
- ✅ `next-env.d.ts`の自動更新も含む

## "bundler"の利点
1. **Next.js最適化** - モダンなバンドラーとの完全互換性
2. **将来対応** - TypeScript 7.0での非推奨警告解消
3. **型解決精度** - より正確なモジュール解決
4. **パフォーマンス** - バンドラー特化の最適化

## テスト結果
✅ 全6テストスイートが正常に通過
✅ プロダクションビルド成功
✅ 警告なしのクリーンなコンパイル

## 変更ファイル
- `tsconfig.json` - moduleResolution設定変更
- `next-env.d.ts` - 自動更新

## 効果
- ❌ TypeScript非推奨警告の解消
- ✅ 将来のTypeScript 7.0対応完了
- ✅ Next.js環境により適した設定

🤖 Generated with [Claude Code](https://claude.com/claude-code)