### PR TITLE
TypeScript baseURL非推奨警告を修正

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -15,6 +15,7 @@
     "resolveJsonModule": true,
     "isolatedModules": true,
     "jsx": "react-jsx",
+    "ignoreDeprecations": "5.0",
     "baseUrl": ".",
     "paths": {
       "@/components/*": ["components/*"]


### PR DESCRIPTION
## Summary
- tsconfig.jsonに`ignoreDeprecations: "5.0"`を追加
- baseURLの非推奨警告を解決

## Test plan
- [x] TypeScriptコンパイルエラーがないことを確認 (`npx tsc --noEmit`)
- [x] 既存の`@/components/*`パス解決が正常に動作することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)