### PR TITLE
feat: Biome設定の詳細定義を完了

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -7,13 +7,25 @@
   },
   "files": {
     "ignoreUnknown": false,
-    "experimentalScannerIgnores": [
-      "node_modules",
-      ".next",
-      "types/generated",
-      "pnpm-lock.yaml",
-      "*.config.js",
-      "*.config.mjs"
+    "includes": [
+      "**/*.js",
+      "**/*.jsx",
+      "**/*.ts",
+      "**/*.tsx",
+      "**/*.json",
+      "!**/node_modules/**",
+      "!**/.next/**",
+      "!**/out/**",
+      "!**/build/**",
+      "!**/dist/**",
+      "!**/types/generated/**",
+      "!**/pnpm-lock.yaml",
+      "!**/*.config.js",
+      "!**/*.config.mjs",
+      "!**/*.config.cjs",
+      "!**/.git/**",
+      "!**/coverage/**",
+      "!**/tsconfig.tsbuildinfo"
     ]
   },
   "formatter": {
@@ -37,7 +49,8 @@
         "useExhaustiveDependencies": "warn"
       },
       "style": {
-        "noNonNullAssertion": "off"
+        "noNonNullAssertion": "off",
+        "useConst": "error"
       },
       "suspicious": {
         "noDebugger": "error",
@@ -46,7 +59,8 @@
           "options": {
             "allow": ["warn", "error", "info"]
           }
-        }
+        },
+        "noExplicitAny": "off"
       }
     }
   },
@@ -55,7 +69,72 @@
       "quoteStyle": "single",
       "semicolons": "always",
       "trailingCommas": "es5",
-      "arrowParentheses": "always"
+      "arrowParentheses": "always",
+      "quoteProperties": "asNeeded",
+      "bracketSpacing": true,
+      "bracketSameLine": false
+    },
+    "globals": [
+      "console",
+      "process",
+      "global",
+      "Buffer",
+      "document",
+      "window",
+      "HTMLElement",
+      "HTMLFormElement",
+      "HTMLInputElement",
+      "Event",
+      "MessageEvent",
+      "BroadcastChannel",
+      "alert",
+      "setTimeout",
+      "clearTimeout",
+      "describe",
+      "it",
+      "test",
+      "expect",
+      "beforeAll",
+      "beforeEach",
+      "afterAll",
+      "afterEach",
+      "jest",
+      "waitFor"
+    ]
+  },
+  "overrides": [
+    {
+      "includes": [
+        "**/*.config.{js,ts}",
+        "**/jest.*.{js,ts}",
+        "**/__mocks__/**/*.{js,ts}"
+      ],
+      "linter": {
+        "rules": {
+          "suspicious": {
+            "noConsole": "off"
+          },
+          "correctness": {
+            "noUnusedVariables": "off"
+          }
+        }
+      }
+    },
+    {
+      "includes": [
+        "**/*.test.{js,jsx,ts,tsx}",
+        "**/__tests__/**/*.{js,jsx,ts,tsx}"
+      ],
+      "linter": {
+        "rules": {
+          "suspicious": {
+            "noConsole": "off"
+          },
+          "correctness": {
+            "noUnusedVariables": "off"
+          }
+        }
+      }
     }
-  }
+  ]
 }


### PR DESCRIPTION
- フォーマッター設定をPrettierと同等に設定（シングルクォート、セミコロン、インデント幅2）
- リンター設定をESLintルールに合わせて設定（未使用変数、React Hooks、console警告）
- JavaScript/TypeScript固有の設定を追加（グローバル変数定義）
- ファイル除外パターンを設定（node_modules、.next、types/generated等）
- テストファイルとconfigファイル用のオーバーライド設定を追加
