### PR TITLE
リポジトリ公開準備: 自インフラ識別子の汎用化と MIT ライセンス追加

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,1 +1,2 @@
 export GH_CONFIG_DIR=$PWD/.config/gh
+dotenv_if_exists .env.local

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 kakikubo
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ pnpm install
 
 1. [Hasura Cloud](https://hasura.io/cloud/)にて、GitHub アカウントで認証し、新規プロジェクトを作成します。
 2. Heroku と連携してデータベースインスタンスを構築します。
-3. プロジェクトダッシュボード: [kakikubo-hasura](https://cloud.hasura.io/project/240cecde-58ae-4f75-a05f-1a3fc5b098d6/console/api/api-explorer)
+3. プロジェクトダッシュボード（`https://cloud.hasura.io/project/<your-project-id>/console`）から GraphQL エンドポイント URL を控えます。
 
 ### 2. Vercel へのデプロイ
 

--- a/codegen.yml
+++ b/codegen.yml
@@ -1,5 +1,8 @@
 overwrite: true
-schema: 'https://kakikubo-hasura.hasura.app/v1/graphql'
+schema:
+  - ${NEXT_PUBLIC_HASURA_URL}:
+      headers:
+        x-hasura-admin-secret: ${NEXT_PUBLIC_HASURA_KEY}
 documents: 'queries/**/*.ts'
 generates:
   types/generated/graphql.tsx:


### PR DESCRIPTION
## 目的

リポジトリを public 化する前準備。実インフラ識別子の汎用化とライセンス付与を行う。

## 変更内容

- **codegen.yml**: ハードコードされた実 Hasura エンドポイントを env 参照化
  - `schema` を `${NEXT_PUBLIC_HASURA_URL}` 参照へ変更
  - イントロスペクションに `x-hasura-admin-secret: ${NEXT_PUBLIC_HASURA_KEY}` ヘッダを追加（`lib/apolloClient.ts` と同じ env を使用、リポジトリにリテラル秘密を残さない）
- **.envrc**: `dotenv_if_exists .env.local` を追加し、direnv 経由で codegen 実行時に env を供給（`pnpm gen-types` 非破壊）
- **README.md**: プロジェクトUUID入りダッシュボードURLを汎用手順に置換
- **LICENSE**: MIT ライセンスを新規追加（`Copyright (c) 2026 kakikubo`）

## 背景・確認事項

- git 全履歴（全コミット・全ブランチ・stash・reflog）を独立スキャンし、実認証情報の混入が無いことを確認済み → **履歴書き換えは不要**
- 旧 Hasura インスタンスは削除・再作成済みのため、履歴上のエンドポイント識別子は無効化済み
- `pnpm gen-types` が新インスタンスに対し正常完走することを検証済み

## スコープ外（別PR予定）

- Hasura スキーマ（migrations / metadata）のリポジトリ管理化
- codegen v6 形式への生成型再生成（`types/generated/graphql.tsx`）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated setup to instruct copying the GraphQL endpoint URL from the Hasura console instead of using hardcoded example links.

* **Chores**
  * Added an MIT License file.
  * Improved environment configuration to optionally load local variables and to use environment-driven GraphQL endpoint and admin key for schema generation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kakikubo/learning-hasura/pull/1788?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->