### PR TITLE
codegen を型生成のみにして Apollo Client v4 互換化

### DIFF
--- a/codegen.yml
+++ b/codegen.yml
@@ -9,13 +9,7 @@ generates:
     plugins:
       - 'typescript'
       - 'typescript-operations'
-      - 'typescript-react-apollo'
     config:
-      apolloClientVersion: 4
-      gqlImport: '@apollo/client#gql'
-      withHooks: true
-      withComponent: false
-      withHOC: false
       strictScalars: true
       scalars:
         timestamptz: string

--- a/components/UserItem.tsx
+++ b/components/UserItem.tsx
@@ -1,11 +1,19 @@
 import React, { FC, memo, Dispatch, SetStateAction } from 'react';
-import { Users, DeleteUserMutationFn } from '../types/generated/graphql';
+import type { MutationTuple } from '@apollo/client/react';
+import type {
+  Users,
+  DeleteUserMutation,
+  DeleteUserMutationVariables,
+} from '../types/generated/graphql';
 
 interface Props {
   user: {
     __typename?: 'users';
   } & Pick<Users, 'id' | 'name' | 'created_at'>;
-  delete_users_by_pk: DeleteUserMutationFn;
+  delete_users_by_pk: MutationTuple<
+    DeleteUserMutation,
+    DeleteUserMutationVariables
+  >[0];
   setEditedUser: Dispatch<
     SetStateAction<{
       id: string;

--- a/package.json
+++ b/package.json
@@ -38,7 +38,6 @@
     "@graphql-codegen/cli": "^7.0.0",
     "@graphql-codegen/typescript": "^6.0.0",
     "@graphql-codegen/typescript-operations": "^6.0.2",
-    "@graphql-codegen/typescript-react-apollo": "^4.3.3",
     "@mswjs/interceptors": "^0.41.0",
     "@tailwindcss/postcss": "^4.1.4",
     "@testing-library/dom": "^10.0.0",

--- a/pages/hasura-crud.tsx
+++ b/pages/hasura-crud.tsx
@@ -10,6 +10,7 @@ import {
   GetUsersQuery,
   CreateUserMutation,
   DeleteUserMutation,
+  DeleteUserMutationVariables,
   UpdateUserMutation,
 } from '../types/generated/graphql';
 import { Layout } from '@/components/Layout';
@@ -37,7 +38,10 @@ const HasuraCRUD: FC = () => {
       }
     },
   });
-  const [delete_users_by_pk] = useMutation<DeleteUserMutation>(DELETE_USER, {
+  const [delete_users_by_pk] = useMutation<
+    DeleteUserMutation,
+    DeleteUserMutationVariables
+  >(DELETE_USER, {
     update(cache, { data }) {
       if (data?.delete_users_by_pk) {
         cache.modify({

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -51,9 +51,6 @@ importers:
       '@graphql-codegen/typescript-operations':
         specifier: ^6.0.2
         version: 6.0.2(graphql@16.14.0)
-      '@graphql-codegen/typescript-react-apollo':
-        specifier: ^4.3.3
-        version: 4.4.2(graphql@16.14.0)
       '@mswjs/interceptors':
         specifier: ^0.41.0
         version: 0.41.9
@@ -425,12 +422,6 @@ packages:
     peerDependencies:
       graphql: ^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0
 
-  '@graphql-codegen/plugin-helpers@6.3.0':
-    resolution: {integrity: sha512-Auc+/B7okDx9+pVgLVliZtZLYh6iltWXlnzzM+bRE+zh1T4r3hKbnr8xAmtT937ArfSgk5GHcQHr8LfPYnrRBg==}
-    engines: {node: '>=16'}
-    peerDependencies:
-      graphql: ^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0
-
   '@graphql-codegen/plugin-helpers@7.0.1':
     resolution: {integrity: sha512-S2X0YT3XQbP2haqhIeku8GOXo2j8QuBu7BrLsOEHz4UeMu78y3rja1Q4ri3oJ0jq4dMgaQlazoVHI/A+FAKMGw==}
     engines: {node: '>=16'}
@@ -459,23 +450,11 @@ packages:
       graphql-sock:
         optional: true
 
-  '@graphql-codegen/typescript-react-apollo@4.4.2':
-    resolution: {integrity: sha512-S/VQeLWMNzo/WnUpvCQELqh2qgAK4H9kkWyC8JrrrPHaV3w/BmOwzeHpcwlHKcuSYWRH6u61XPRQ5+eCjj00AQ==}
-    engines: {node: '>= 16.0.0'}
-    peerDependencies:
-      graphql: ^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0
-
   '@graphql-codegen/typescript@6.0.1':
     resolution: {integrity: sha512-UmHKlOBqnmGs0ioZsfi7INIb6+YCXVMi3KSp/INO359fT3RJxWPLPiE7T30UaWXtLeO6fBNZcvhy3EGBI9UCvw==}
     engines: {node: '>=16'}
     peerDependencies:
       graphql: ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0
-
-  '@graphql-codegen/visitor-plugin-common@6.3.0':
-    resolution: {integrity: sha512-vGBoE+4huzZyNhyGSAhXAkdROHlwKxxuziZm4XtP1mxe7nuI+VgyOmXebafLijbmuDsptPXQN0C/htL54O8hrg==}
-    engines: {node: '>=16'}
-    peerDependencies:
-      graphql: ^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0
 
   '@graphql-codegen/visitor-plugin-common@7.0.2':
     resolution: {integrity: sha512-3v1dPjkSiAIsqwZ/6btSZ6BCYlYYpr3FdLhsBZ/JoPP2hYgN6AlGKdUyhYm5FsgDKU04L7al3+rfnTOCxqM0gw==}
@@ -597,12 +576,6 @@ packages:
 
   '@graphql-tools/optimize@2.0.0':
     resolution: {integrity: sha512-nhdT+CRGDZ+bk68ic+Jw1OZ99YCDIKYA5AlVAnBHJvMawSx9YQqQAIj4refNc1/LRieGiuWvhbG3jvPVYho0Dg==}
-    engines: {node: '>=16.0.0'}
-    peerDependencies:
-      graphql: ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0
-
-  '@graphql-tools/relay-operation-optimizer@7.1.3':
-    resolution: {integrity: sha512-Vzh5QORIqX0KtwxgNepl/T16a85Br7YbOxxxmnyVpS7yza9vBjkrERbvAwADcYyPH7kyShmH1Gu5+88+vCVhuA==}
     engines: {node: '>=16.0.0'}
     peerDependencies:
       graphql: ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0
@@ -1408,10 +1381,6 @@ packages:
     resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
     engines: {node: '>=12'}
 
-  auto-bind@4.0.0:
-    resolution: {integrity: sha512-Hdw8qdNiqdJ8LqT0iK0sVzkFbzg6fhnQqqfWhBDxcHZvU75+B+ayzTy8x+k5Ix0Y92XOhOUlx74ps+bA6BeYMQ==}
-    engines: {node: '>=8'}
-
   auto-bind@5.0.1:
     resolution: {integrity: sha512-ooviqdwwgfIfNmDwo94wlshcdzfO64XV0Cg6oDsDYBJfITDz1EngD2z7DkbvCWn+XIMsIqW27sEVF6qcpJrRcg==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
@@ -1468,17 +1437,11 @@ packages:
     resolution: {integrity: sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==}
     engines: {node: '>=6'}
 
-  camel-case@4.1.2:
-    resolution: {integrity: sha512-gxGWBrTT1JuMx6R+o5PTXMmUnhnVzLQ9SNutD4YqKtI6ap897t3tKECYla6gCWEkplXnlNybEkZg9GEGxKFCgw==}
-
   caniuse-lite@1.0.30001787:
     resolution: {integrity: sha512-mNcrMN9KeI68u7muanUpEejSLghOKlVhRqS/Za2IeyGllJ9I9otGpR9g3nsw7n4W378TE/LyIteA0+/FOZm4Kg==}
 
   caniuse-lite@1.0.30001792:
     resolution: {integrity: sha512-hVLMUZFgR4JJ6ACt1uEESvQN1/dBVqPAKY0hgrV70eN3391K6juAfTjKZLKvOMsx8PxA7gsY1/tLMMTcfFLLpw==}
-
-  capital-case@1.0.4:
-    resolution: {integrity: sha512-ds37W8CytHgwnhGGTi88pcPyR15qoNkOpYwmMMfnWqqWgESapLqvDx6huFjQ5vqWSn2Z06173XNA7LtMOeUh1A==}
 
   chai@6.2.2:
     resolution: {integrity: sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==}
@@ -1488,14 +1451,8 @@ packages:
     resolution: {integrity: sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==}
     engines: {node: ^12.17.0 || ^14.13 || >=16.0.0}
 
-  change-case-all@1.0.15:
-    resolution: {integrity: sha512-3+GIFhk3sNuvFAJKU46o26OdzudQlPNBCu1ZQi3cMeMHhty1bhDxu2WrEilVNYaGvqUtR1VSigFcJOiS13dRhQ==}
-
   change-case-all@2.1.0:
     resolution: {integrity: sha512-v6b0WWWkZUMHVuYk82l+WROgkUm4qEN2w5hKRNWtEOYwWqUGoi8C6xH0l1RLF1EoWqDFK6MFclmN3od6ws3/uw==}
-
-  change-case@4.1.2:
-    resolution: {integrity: sha512-bSxY2ws9OtviILG1EiY5K7NNxkqg/JnRnFxLtKQ96JaviiIxi7djMrSd0ECT9AC+lttClmYwKw53BWpOMblo7A==}
 
   change-case@5.4.4:
     resolution: {integrity: sha512-HRQyTk2/YPEkt9TnUPbOpr64Uw3KOicFWPVBb+xiHvd6eBx/qPr9xqfBFDT8P2vWsvvz4jbEkfDe71W3VyNu2w==}
@@ -1536,9 +1493,6 @@ packages:
   common-tags@1.8.2:
     resolution: {integrity: sha512-gk/Z852D2Wtb//0I+kRFNKKE9dIIVirjoqPoA1wJU+XePVXZfGeBpk45+A1rKO4Q43prqWBNY/MiIeRLbPWUaA==}
     engines: {node: '>=4.0.0'}
-
-  constant-case@3.0.4:
-    resolution: {integrity: sha512-I2hSBi7Vvs7BEuJDr5dDHfzb/Ruj3FyvFyh7KLilAjNQw3Be+xgqUBA2W6scVEcL0hL1dwPRtIqEPVUCKkSsyQ==}
 
   convert-source-map@2.0.0:
     resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
@@ -1638,9 +1592,6 @@ packages:
 
   dom-accessibility-api@0.6.3:
     resolution: {integrity: sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==}
-
-  dot-case@3.0.4:
-    resolution: {integrity: sha512-Kv5nKlh6yRrdrGvxeJ2e5y2eRUpkUosIW4A2AS38zwSz27zu7ufDwQPi5Jhs3XAlGNetl3bmnGhQsMtkKJnj3w==}
 
   dunder-proto@1.0.1:
     resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
@@ -1845,9 +1796,6 @@ packages:
     resolution: {integrity: sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==}
     engines: {node: '>= 0.4'}
 
-  header-case@2.0.4:
-    resolution: {integrity: sha512-H/vuk5TEEVZwrR0lp2zed9OCo1uAILMlx0JEMgC26rzyJJ3N1v6XkwHHXJQdR2doSjcGPM6OKPYoJgf0plJ11Q==}
-
   headers-polyfill@5.0.1:
     resolution: {integrity: sha512-1TJ6Fih/b8h5TIcv+1+Hw0PDQWJTKDKzFZzcKOiW1wJza3XoAQlkCuXLbymPYB8+ZQyw8mHvdw560e8zVFIWyA==}
 
@@ -1919,9 +1867,6 @@ packages:
     resolution: {integrity: sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==}
     engines: {node: '>=0.10.0'}
 
-  is-lower-case@2.0.2:
-    resolution: {integrity: sha512-bVcMJy4X5Og6VZfdOZstSexlEy20Sr0k/p/b2IlQJlfdKAQuMpiv5w2Ccxb8sKdRUNAG1PnHVHjFSdRDVS6NlQ==}
-
   is-node-process@1.2.0:
     resolution: {integrity: sha512-Vg4o6/fqPxIjtxgUH5QLJhwZ7gW5diGCVlXpuUfELC62CuxM1iHcRe51f2W1FDy04Ai4KJkagKjx3XaqyfRKXw==}
 
@@ -1951,9 +1896,6 @@ packages:
   is-unicode-supported@2.1.0:
     resolution: {integrity: sha512-mE00Gnza5EEB3Ds0HfMyllZzbBrmLOX3vfWoj9A9PEnTfratQ/BcaJOuMhnkhjXvb2+FkY3VuHqtAGpTPmglFQ==}
     engines: {node: '>=18'}
-
-  is-upper-case@2.0.2:
-    resolution: {integrity: sha512-44pxmxAvnnAOwBg4tHPnkfvgjPwbc5QIsSstNU+YcJ1ovxVzCWpSGosPJOZh/a1tdl81fbgnLc9LLv+x2ywbPQ==}
 
   is-windows@1.0.2:
     resolution: {integrity: sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA==}
@@ -2156,12 +2098,6 @@ packages:
     resolution: {integrity: sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==}
     hasBin: true
 
-  lower-case-first@2.0.2:
-    resolution: {integrity: sha512-EVm/rR94FJTZi3zefZ82fLWab+GX14LJN4HrWBcuo6Evmsl9hEfnqxgcHCKb9q+mNf6EVdsjx/qucYFIIB84pg==}
-
-  lower-case@2.0.2:
-    resolution: {integrity: sha512-7fm3l3NAF9WfN6W3JOmf5drwpVqX78JtoGJ3A6W0a6ZnldM41w2fV5D490psKFTpMds8TJse/eHLFFsNHHjHgg==}
-
   lru-cache@11.3.5:
     resolution: {integrity: sha512-NxVFwLAnrd9i7KUBxC4DrUhmgjzOs+1Qm50D3oF1/oL+r1NpZ4gA7xvG0/zJ8evR7zIKn4vLf7qTNduWFtCrRw==}
     engines: {node: 20 || >=22}
@@ -2259,9 +2195,6 @@ packages:
       sass:
         optional: true
 
-  no-case@3.0.4:
-    resolution: {integrity: sha512-fgAN3jGAh+RoxUGZHTSOLJIqUc2wmoBwGR4tbpNAKmmovFoWq0OdRkb0VkldReO2a2iBT/OEulG9XSUc10r3zg==}
-
   node-domexception@1.0.0:
     resolution: {integrity: sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==}
     engines: {node: '>=10.5.0'}
@@ -2304,9 +2237,6 @@ packages:
     resolution: {integrity: sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==}
     engines: {node: '>=10'}
 
-  param-case@3.0.4:
-    resolution: {integrity: sha512-RXlj7zCYokReqWpOPH9oYivUzLYZ5vAPIfEmCTNViosC78F8F0H9y7T7gG2M39ymgutxF5gcFEsyZQSph9Bp3A==}
-
   parent-module@1.0.1:
     resolution: {integrity: sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==}
     engines: {node: '>=6'}
@@ -2321,12 +2251,6 @@ packages:
 
   parse5@8.0.1:
     resolution: {integrity: sha512-z1e/HMG90obSGeidlli3hj7cbocou0/wa5HacvI3ASx34PecNjNQeaHNo5WIZpWofN9kgkqV1q5YvXe3F0FoPw==}
-
-  pascal-case@3.1.2:
-    resolution: {integrity: sha512-uWlGT3YSnK9x3BQJaOdcZwrnV6hPpd8jFH1/ucpiLRPh/2zCVJKS19E4GvYHvaCcACn3foXZ0cLB9Wrx1KGe5g==}
-
-  path-case@3.0.4:
-    resolution: {integrity: sha512-qO4qCFjXqVTrcbPt/hQfhTQ+VhFsqNKOPtytgNKkKxSoEp3XPUQ8ObFuePylOIok5gjn69ry8XiULxCwot3Wfg==}
 
   path-root-regex@0.1.2:
     resolution: {integrity: sha512-4GlJ6rZDhQZFE0DPVKh0e9jmZ5egZfxTkp7bcRDuPlJXbAwhxcl2dINPUAsjLdejqaLsCeg8axcLjIbvBjN4pQ==}
@@ -2472,9 +2396,6 @@ packages:
     engines: {node: '>=10'}
     hasBin: true
 
-  sentence-case@3.0.4:
-    resolution: {integrity: sha512-8LS0JInaQMCRoQ7YUytAo/xUu5W2XnQxV2HI/6uM6U7CITS1RqPElr30V6uIqyMKM9lJGRVFy5/4CuzcixNYSg==}
-
   set-cookie-parser@3.1.0:
     resolution: {integrity: sha512-kjnC1DXBHcxaOaOXBHBeRtltsDG2nUiUni+jP92M9gYdW12rsmx92UsfpH7o5tDRs7I1ZZPSQJQGv3UaRfCiuw==}
 
@@ -2512,15 +2433,9 @@ packages:
     resolution: {integrity: sha512-stxByr12oeeOyY2BlviTNQlYV5xOj47GirPr4yA1hE9JCtxfQN0+tVbkxwCtYDQWhEKWFHsEK48ORg5jrouCAg==}
     engines: {node: '>=20'}
 
-  snake-case@3.0.4:
-    resolution: {integrity: sha512-LAOh4z89bGQvl9pFfNF8V146i7o7/CqFPbqzYgP+yYzDIDeS9HaNFtXABamRW+AQzEVODcvE79ljJ+8a9YSdMg==}
-
   source-map-js@1.2.1:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
     engines: {node: '>=0.10.0'}
-
-  sponge-case@1.0.1:
-    resolution: {integrity: sha512-dblb9Et4DAtiZ5YSUZHLl4XhH4uK80GhAZrVXdN4O2P4gQ40Wa5UIOPUHlA/nFd2PLblBZWUioLMMAVrgpoYcA==}
 
   sponge-case@2.0.3:
     resolution: {integrity: sha512-i4h9ZGRfxV6Xw3mpZSFOfbXjf0cQcYmssGWutgNIfFZ2VM+YIWfD71N/kjjwK6X/AAHzBr+rciEcn/L34S8TGw==}
@@ -2577,9 +2492,6 @@ packages:
         optional: true
       babel-plugin-macros:
         optional: true
-
-  swap-case@2.0.2:
-    resolution: {integrity: sha512-kc6S2YS/2yXbtkSMunBtKdah4VFETZ8Oh6ONSmSd9bRxhqTrtARUCBUiWXH3xVPpvR7tz2CSnkuXVE42EcGnMw==}
 
   swap-case@3.0.3:
     resolution: {integrity: sha512-6p4op8wE9CQv7uDFzulI6YXUw4lD9n4oQierdbFThEKVWVQcbQcUjdP27W8XE7V4QnWmnq9jueSHceyyQnqQVA==}
@@ -2685,12 +2597,6 @@ packages:
     hasBin: true
     peerDependencies:
       browserslist: '>= 4.21.0'
-
-  upper-case-first@2.0.2:
-    resolution: {integrity: sha512-514ppYHBaKwfJRK/pNC6c/OxfGa0obSnAl106u97Ed0I625Nin96KAjttZF6ZL3e1XLtphxnqrOi9iWgm+u+bg==}
-
-  upper-case@2.0.2:
-    resolution: {integrity: sha512-KgdgDGJt2TpuwBUIjgG6lzw2GWFRCW9Qkfkiv0DxqHHLYJHmtmdUIKcZd8rHgFSjopVTlw6ggzCm1b8MFQwikg==}
 
   urlpattern-polyfill@10.1.0:
     resolution: {integrity: sha512-IGjKp/o0NL3Bso1PymYURCJxMPNAf/ILOpendP9f5B6e1rTJgdgiOvgfoT8VxCAdY+Wisb9uhGaJJf3yZ2V9nw==}
@@ -3254,15 +3160,6 @@ snapshots:
       graphql: 16.14.0
       tslib: 2.8.1
 
-  '@graphql-codegen/plugin-helpers@6.3.0(graphql@16.14.0)':
-    dependencies:
-      '@graphql-tools/utils': 11.1.0(graphql@16.14.0)
-      change-case-all: 1.0.15
-      common-tags: 1.8.2
-      graphql: 16.14.0
-      import-from: 4.0.0
-      tslib: 2.8.1
-
   '@graphql-codegen/plugin-helpers@7.0.1(graphql@16.14.0)':
     dependencies:
       '@graphql-tools/utils': 11.1.0(graphql@16.14.0)
@@ -3297,15 +3194,6 @@ snapshots:
       graphql: 16.14.0
       tslib: 2.8.1
 
-  '@graphql-codegen/typescript-react-apollo@4.4.2(graphql@16.14.0)':
-    dependencies:
-      '@graphql-codegen/plugin-helpers': 6.3.0(graphql@16.14.0)
-      '@graphql-codegen/visitor-plugin-common': 6.3.0(graphql@16.14.0)
-      auto-bind: 4.0.0
-      change-case-all: 1.0.15
-      graphql: 16.14.0
-      tslib: 2.8.1
-
   '@graphql-codegen/typescript@6.0.1(graphql@16.14.0)':
     dependencies:
       '@graphql-codegen/plugin-helpers': 7.0.1(graphql@16.14.0)
@@ -3313,20 +3201,6 @@ snapshots:
       '@graphql-codegen/visitor-plugin-common': 7.0.2(graphql@16.14.0)
       auto-bind: 5.0.1
       graphql: 16.14.0
-      tslib: 2.8.1
-
-  '@graphql-codegen/visitor-plugin-common@6.3.0(graphql@16.14.0)':
-    dependencies:
-      '@graphql-codegen/plugin-helpers': 6.3.0(graphql@16.14.0)
-      '@graphql-tools/optimize': 2.0.0(graphql@16.14.0)
-      '@graphql-tools/relay-operation-optimizer': 7.1.3(graphql@16.14.0)
-      '@graphql-tools/utils': 11.1.0(graphql@16.14.0)
-      auto-bind: 4.0.0
-      change-case-all: 1.0.15
-      dependency-graph: 1.0.0
-      graphql: 16.14.0
-      graphql-tag: 2.12.6(graphql@16.14.0)
-      parse-filepath: 1.0.2
       tslib: 2.8.1
 
   '@graphql-codegen/visitor-plugin-common@7.0.2(graphql@16.14.0)':
@@ -3528,13 +3402,6 @@ snapshots:
 
   '@graphql-tools/optimize@2.0.0(graphql@16.14.0)':
     dependencies:
-      graphql: 16.14.0
-      tslib: 2.8.1
-
-  '@graphql-tools/relay-operation-optimizer@7.1.3(graphql@16.14.0)':
-    dependencies:
-      '@ardatan/relay-compiler': 13.0.1(graphql@16.14.0)
-      '@graphql-tools/utils': 11.1.0(graphql@16.14.0)
       graphql: 16.14.0
       tslib: 2.8.1
 
@@ -4208,8 +4075,6 @@ snapshots:
 
   assertion-error@2.0.1: {}
 
-  auto-bind@4.0.0: {}
-
   auto-bind@5.0.1: {}
 
   autoprefixer@10.5.0(postcss@8.5.14):
@@ -4268,37 +4133,13 @@ snapshots:
 
   callsites@3.1.0: {}
 
-  camel-case@4.1.2:
-    dependencies:
-      pascal-case: 3.1.2
-      tslib: 2.8.1
-
   caniuse-lite@1.0.30001787: {}
 
   caniuse-lite@1.0.30001792: {}
 
-  capital-case@1.0.4:
-    dependencies:
-      no-case: 3.0.4
-      tslib: 2.8.1
-      upper-case-first: 2.0.2
-
   chai@6.2.2: {}
 
   chalk@5.6.2: {}
-
-  change-case-all@1.0.15:
-    dependencies:
-      change-case: 4.1.2
-      is-lower-case: 2.0.2
-      is-upper-case: 2.0.2
-      lower-case: 2.0.2
-      lower-case-first: 2.0.2
-      sponge-case: 1.0.1
-      swap-case: 2.0.2
-      title-case: 3.0.3
-      upper-case: 2.0.2
-      upper-case-first: 2.0.2
 
   change-case-all@2.1.0:
     dependencies:
@@ -4306,21 +4147,6 @@ snapshots:
       sponge-case: 2.0.3
       swap-case: 3.0.3
       title-case: 3.0.3
-
-  change-case@4.1.2:
-    dependencies:
-      camel-case: 4.1.2
-      capital-case: 1.0.4
-      constant-case: 3.0.4
-      dot-case: 3.0.4
-      header-case: 2.0.4
-      no-case: 3.0.4
-      param-case: 3.0.4
-      pascal-case: 3.1.2
-      path-case: 3.0.4
-      sentence-case: 3.0.4
-      snake-case: 3.0.4
-      tslib: 2.8.1
 
   change-case@5.4.4: {}
 
@@ -4358,12 +4184,6 @@ snapshots:
   color-name@1.1.4: {}
 
   common-tags@1.8.2: {}
-
-  constant-case@3.0.4:
-    dependencies:
-      no-case: 3.0.4
-      tslib: 2.8.1
-      upper-case: 2.0.2
 
   convert-source-map@2.0.0: {}
 
@@ -4446,11 +4266,6 @@ snapshots:
   dom-accessibility-api@0.5.16: {}
 
   dom-accessibility-api@0.6.3: {}
-
-  dot-case@3.0.4:
-    dependencies:
-      no-case: 3.0.4
-      tslib: 2.8.1
 
   dunder-proto@1.0.1:
     dependencies:
@@ -4641,11 +4456,6 @@ snapshots:
     dependencies:
       function-bind: 1.1.2
 
-  header-case@2.0.4:
-    dependencies:
-      capital-case: 1.0.4
-      tslib: 2.8.1
-
   headers-polyfill@5.0.1:
     dependencies:
       '@types/set-cookie-parser': 2.4.10
@@ -4714,10 +4524,6 @@ snapshots:
     dependencies:
       is-extglob: 2.1.1
 
-  is-lower-case@2.0.2:
-    dependencies:
-      tslib: 2.8.1
-
   is-node-process@1.2.0: {}
 
   is-number@7.0.0: {}
@@ -4744,10 +4550,6 @@ snapshots:
       unc-path-regex: 0.1.2
 
   is-unicode-supported@2.1.0: {}
-
-  is-upper-case@2.0.2:
-    dependencies:
-      tslib: 2.8.1
 
   is-windows@1.0.2: {}
 
@@ -4925,14 +4727,6 @@ snapshots:
     dependencies:
       js-tokens: 4.0.0
 
-  lower-case-first@2.0.2:
-    dependencies:
-      tslib: 2.8.1
-
-  lower-case@2.0.2:
-    dependencies:
-      tslib: 2.8.1
-
   lru-cache@11.3.5: {}
 
   lru-cache@5.1.1:
@@ -5025,11 +4819,6 @@ snapshots:
       - '@babel/core'
       - babel-plugin-macros
 
-  no-case@3.0.4:
-    dependencies:
-      lower-case: 2.0.2
-      tslib: 2.8.1
-
   node-domexception@1.0.0: {}
 
   node-fetch@2.7.0:
@@ -5067,11 +4856,6 @@ snapshots:
     dependencies:
       yocto-queue: 0.1.0
 
-  param-case@3.0.4:
-    dependencies:
-      dot-case: 3.0.4
-      tslib: 2.8.1
-
   parent-module@1.0.1:
     dependencies:
       callsites: 3.1.0
@@ -5092,16 +4876,6 @@ snapshots:
   parse5@8.0.1:
     dependencies:
       entities: 8.0.0
-
-  pascal-case@3.1.2:
-    dependencies:
-      no-case: 3.0.4
-      tslib: 2.8.1
-
-  path-case@3.0.4:
-    dependencies:
-      dot-case: 3.0.4
-      tslib: 2.8.1
 
   path-root-regex@0.1.2: {}
 
@@ -5234,12 +5008,6 @@ snapshots:
   semver@7.7.4:
     optional: true
 
-  sentence-case@3.0.4:
-    dependencies:
-      no-case: 3.0.4
-      tslib: 2.8.1
-      upper-case-first: 2.0.2
-
   set-cookie-parser@3.1.0: {}
 
   set-function-length@1.2.2:
@@ -5303,16 +5071,7 @@ snapshots:
       ansi-styles: 6.2.3
       is-fullwidth-code-point: 5.1.0
 
-  snake-case@3.0.4:
-    dependencies:
-      dot-case: 3.0.4
-      tslib: 2.8.1
-
   source-map-js@1.2.1: {}
-
-  sponge-case@1.0.1:
-    dependencies:
-      tslib: 2.8.1
 
   sponge-case@2.0.3: {}
 
@@ -5361,10 +5120,6 @@ snapshots:
       react: 19.2.6
     optionalDependencies:
       '@babel/core': 7.29.0
-
-  swap-case@2.0.2:
-    dependencies:
-      tslib: 2.8.1
 
   swap-case@3.0.3: {}
 
@@ -5446,14 +5201,6 @@ snapshots:
       browserslist: 4.28.2
       escalade: 3.2.0
       picocolors: 1.1.1
-
-  upper-case-first@2.0.2:
-    dependencies:
-      tslib: 2.8.1
-
-  upper-case@2.0.2:
-    dependencies:
-      tslib: 2.8.1
 
   urlpattern-polyfill@10.1.0: {}
 

--- a/types/generated/graphql.tsx
+++ b/types/generated/graphql.tsx
@@ -1,334 +1,92 @@
-import { gql } from '@apollo/client';
-import * as Apollo from '@apollo/client';
-import { useQuery, useLazyQuery, useMutation } from '@apollo/client/react';
+/** Internal type. DO NOT USE DIRECTLY. */
+type Exact<T extends { [key: string]: unknown }> = { [K in keyof T]: T[K] };
+/** Internal type. DO NOT USE DIRECTLY. */
+export type Incremental<T> = T | { [P in keyof T]?: P extends ' $fragmentName' | '__typename' ? T[P] : never };
 export type Maybe<T> = T | null;
 export type InputMaybe<T> = Maybe<T>;
-export type Exact<T extends { [key: string]: unknown }> = {
-  [K in keyof T]: T[K];
-};
-export type MakeOptional<T, K extends keyof T> = Omit<T, K> & {
-  [SubKey in K]?: Maybe<T[SubKey]>;
-};
-export type MakeMaybe<T, K extends keyof T> = Omit<T, K> & {
-  [SubKey in K]: Maybe<T[SubKey]>;
-};
-const defaultOptions = {};
 /** All built-in and custom scalars, mapped to their actual values */
 export type Scalars = {
-  ID: string;
-  String: string;
-  Boolean: boolean;
-  Int: number;
-  Float: number;
-  timestamptz: any;
-  uuid: string;
+  ID: { input: string; output: string; }
+  String: { input: string; output: string; }
+  Boolean: { input: boolean; output: boolean; }
+  Int: { input: number; output: number; }
+  Float: { input: number; output: number; }
+  timestamptz: { input: string; output: string; }
+  uuid: { input: string; output: string; }
 };
 
 /** Boolean expression to compare columns of type "String". All fields are combined with logical 'AND'. */
 export type String_Comparison_Exp = {
-  _eq?: InputMaybe<Scalars['String']>;
-  _gt?: InputMaybe<Scalars['String']>;
-  _gte?: InputMaybe<Scalars['String']>;
+  _eq?: InputMaybe<Scalars['String']['input']>;
+  _gt?: InputMaybe<Scalars['String']['input']>;
+  _gte?: InputMaybe<Scalars['String']['input']>;
   /** does the column match the given case-insensitive pattern */
-  _ilike?: InputMaybe<Scalars['String']>;
-  _in?: InputMaybe<Array<Scalars['String']>>;
+  _ilike?: InputMaybe<Scalars['String']['input']>;
+  _in?: InputMaybe<Array<Scalars['String']['input']>>;
   /** does the column match the given POSIX regular expression, case insensitive */
-  _iregex?: InputMaybe<Scalars['String']>;
-  _is_null?: InputMaybe<Scalars['Boolean']>;
+  _iregex?: InputMaybe<Scalars['String']['input']>;
+  _is_null?: InputMaybe<Scalars['Boolean']['input']>;
   /** does the column match the given pattern */
-  _like?: InputMaybe<Scalars['String']>;
-  _lt?: InputMaybe<Scalars['String']>;
-  _lte?: InputMaybe<Scalars['String']>;
-  _neq?: InputMaybe<Scalars['String']>;
+  _like?: InputMaybe<Scalars['String']['input']>;
+  _lt?: InputMaybe<Scalars['String']['input']>;
+  _lte?: InputMaybe<Scalars['String']['input']>;
+  _neq?: InputMaybe<Scalars['String']['input']>;
   /** does the column NOT match the given case-insensitive pattern */
-  _nilike?: InputMaybe<Scalars['String']>;
-  _nin?: InputMaybe<Array<Scalars['String']>>;
+  _nilike?: InputMaybe<Scalars['String']['input']>;
+  _nin?: InputMaybe<Array<Scalars['String']['input']>>;
   /** does the column NOT match the given POSIX regular expression, case insensitive */
-  _niregex?: InputMaybe<Scalars['String']>;
+  _niregex?: InputMaybe<Scalars['String']['input']>;
   /** does the column NOT match the given pattern */
-  _nlike?: InputMaybe<Scalars['String']>;
+  _nlike?: InputMaybe<Scalars['String']['input']>;
   /** does the column NOT match the given POSIX regular expression, case sensitive */
-  _nregex?: InputMaybe<Scalars['String']>;
+  _nregex?: InputMaybe<Scalars['String']['input']>;
   /** does the column NOT match the given SQL regular expression */
-  _nsimilar?: InputMaybe<Scalars['String']>;
+  _nsimilar?: InputMaybe<Scalars['String']['input']>;
   /** does the column match the given POSIX regular expression, case sensitive */
-  _regex?: InputMaybe<Scalars['String']>;
+  _regex?: InputMaybe<Scalars['String']['input']>;
   /** does the column match the given SQL regular expression */
-  _similar?: InputMaybe<Scalars['String']>;
+  _similar?: InputMaybe<Scalars['String']['input']>;
 };
 
-/** columns and relationships of "groups" */
-export type Groups = {
-  __typename?: 'groups';
-  id: Scalars['uuid'];
-  name: Scalars['String'];
-  /** An array relationship */
-  users: Array<Users>;
-  /** An aggregate relationship */
-  users_aggregate: Users_Aggregate;
-};
-
-/** columns and relationships of "groups" */
-export type GroupsUsersArgs = {
-  distinct_on?: InputMaybe<Array<Users_Select_Column>>;
-  limit?: InputMaybe<Scalars['Int']>;
-  offset?: InputMaybe<Scalars['Int']>;
-  order_by?: InputMaybe<Array<Users_Order_By>>;
-  where?: InputMaybe<Users_Bool_Exp>;
-};
-
-/** columns and relationships of "groups" */
-export type GroupsUsers_AggregateArgs = {
-  distinct_on?: InputMaybe<Array<Users_Select_Column>>;
-  limit?: InputMaybe<Scalars['Int']>;
-  offset?: InputMaybe<Scalars['Int']>;
-  order_by?: InputMaybe<Array<Users_Order_By>>;
-  where?: InputMaybe<Users_Bool_Exp>;
-};
-
-/** aggregated selection of "groups" */
-export type Groups_Aggregate = {
-  __typename?: 'groups_aggregate';
-  aggregate?: Maybe<Groups_Aggregate_Fields>;
-  nodes: Array<Groups>;
-};
-
-/** aggregate fields of "groups" */
-export type Groups_Aggregate_Fields = {
-  __typename?: 'groups_aggregate_fields';
-  count: Scalars['Int'];
-  max?: Maybe<Groups_Max_Fields>;
-  min?: Maybe<Groups_Min_Fields>;
-};
-
-/** aggregate fields of "groups" */
-export type Groups_Aggregate_FieldsCountArgs = {
-  columns?: InputMaybe<Array<Groups_Select_Column>>;
-  distinct?: InputMaybe<Scalars['Boolean']>;
-};
-
-/** Boolean expression to filter rows from the table "groups". All fields are combined with a logical 'AND'. */
-export type Groups_Bool_Exp = {
-  _and?: InputMaybe<Array<Groups_Bool_Exp>>;
-  _not?: InputMaybe<Groups_Bool_Exp>;
-  _or?: InputMaybe<Array<Groups_Bool_Exp>>;
-  id?: InputMaybe<Uuid_Comparison_Exp>;
-  name?: InputMaybe<String_Comparison_Exp>;
-  users?: InputMaybe<Users_Bool_Exp>;
-};
-
-/** unique or primary key constraints on table "groups" */
-export enum Groups_Constraint {
-  /** unique or primary key constraint */
-  GroupsPkey = 'groups_pkey',
-}
-
-/** input type for inserting data into table "groups" */
-export type Groups_Insert_Input = {
-  id?: InputMaybe<Scalars['uuid']>;
-  name?: InputMaybe<Scalars['String']>;
-  users?: InputMaybe<Users_Arr_Rel_Insert_Input>;
-};
-
-/** aggregate max on columns */
-export type Groups_Max_Fields = {
-  __typename?: 'groups_max_fields';
-  id?: Maybe<Scalars['uuid']>;
-  name?: Maybe<Scalars['String']>;
-};
-
-/** aggregate min on columns */
-export type Groups_Min_Fields = {
-  __typename?: 'groups_min_fields';
-  id?: Maybe<Scalars['uuid']>;
-  name?: Maybe<Scalars['String']>;
-};
-
-/** response of any mutation on the table "groups" */
-export type Groups_Mutation_Response = {
-  __typename?: 'groups_mutation_response';
-  /** number of rows affected by the mutation */
-  affected_rows: Scalars['Int'];
-  /** data from the rows affected by the mutation */
-  returning: Array<Groups>;
-};
-
-/** input type for inserting object relation for remote table "groups" */
-export type Groups_Obj_Rel_Insert_Input = {
-  data: Groups_Insert_Input;
-  /** on conflict condition */
-  on_conflict?: InputMaybe<Groups_On_Conflict>;
-};
-
-/** on conflict condition type for table "groups" */
-export type Groups_On_Conflict = {
-  constraint: Groups_Constraint;
-  update_columns?: Array<Groups_Update_Column>;
-  where?: InputMaybe<Groups_Bool_Exp>;
-};
-
-/** Ordering options when selecting data from "groups". */
-export type Groups_Order_By = {
-  id?: InputMaybe<Order_By>;
-  name?: InputMaybe<Order_By>;
-  users_aggregate?: InputMaybe<Users_Aggregate_Order_By>;
-};
-
-/** primary key columns input for table: groups */
-export type Groups_Pk_Columns_Input = {
-  id: Scalars['uuid'];
-};
-
-/** select columns of table "groups" */
-export enum Groups_Select_Column {
-  /** column name */
-  Id = 'id',
-  /** column name */
-  Name = 'name',
-}
-
-/** input type for updating data in table "groups" */
-export type Groups_Set_Input = {
-  id?: InputMaybe<Scalars['uuid']>;
-  name?: InputMaybe<Scalars['String']>;
-};
-
-/** update columns of table "groups" */
-export enum Groups_Update_Column {
-  /** column name */
-  Id = 'id',
-  /** column name */
-  Name = 'name',
+/** ordering argument of a cursor */
+export enum Cursor_Ordering {
+  /** ascending ordering of the cursor */
+  Asc = 'ASC',
+  /** descending ordering of the cursor */
+  Desc = 'DESC'
 }
 
 /** mutation root */
 export type Mutation_Root = {
   __typename?: 'mutation_root';
-  /** delete data from the table: "groups" */
-  delete_groups?: Maybe<Groups_Mutation_Response>;
-  /** delete single row from the table: "groups" */
-  delete_groups_by_pk?: Maybe<Groups>;
-  /** delete data from the table: "profile_users" */
-  delete_profile_users?: Maybe<Profile_Users_Mutation_Response>;
-  /** delete single row from the table: "profile_users" */
-  delete_profile_users_by_pk?: Maybe<Profile_Users>;
-  /** delete data from the table: "profiles" */
-  delete_profiles?: Maybe<Profiles_Mutation_Response>;
-  /** delete single row from the table: "profiles" */
-  delete_profiles_by_pk?: Maybe<Profiles>;
   /** delete data from the table: "users" */
   delete_users?: Maybe<Users_Mutation_Response>;
   /** delete single row from the table: "users" */
   delete_users_by_pk?: Maybe<Users>;
-  /** insert data into the table: "groups" */
-  insert_groups?: Maybe<Groups_Mutation_Response>;
-  /** insert a single row into the table: "groups" */
-  insert_groups_one?: Maybe<Groups>;
-  /** insert data into the table: "profile_users" */
-  insert_profile_users?: Maybe<Profile_Users_Mutation_Response>;
-  /** insert a single row into the table: "profile_users" */
-  insert_profile_users_one?: Maybe<Profile_Users>;
-  /** insert data into the table: "profiles" */
-  insert_profiles?: Maybe<Profiles_Mutation_Response>;
-  /** insert a single row into the table: "profiles" */
-  insert_profiles_one?: Maybe<Profiles>;
   /** insert data into the table: "users" */
   insert_users?: Maybe<Users_Mutation_Response>;
   /** insert a single row into the table: "users" */
   insert_users_one?: Maybe<Users>;
-  /** update data of the table: "groups" */
-  update_groups?: Maybe<Groups_Mutation_Response>;
-  /** update single row of the table: "groups" */
-  update_groups_by_pk?: Maybe<Groups>;
-  /** update data of the table: "profile_users" */
-  update_profile_users?: Maybe<Profile_Users_Mutation_Response>;
-  /** update single row of the table: "profile_users" */
-  update_profile_users_by_pk?: Maybe<Profile_Users>;
-  /** update data of the table: "profiles" */
-  update_profiles?: Maybe<Profiles_Mutation_Response>;
-  /** update single row of the table: "profiles" */
-  update_profiles_by_pk?: Maybe<Profiles>;
   /** update data of the table: "users" */
   update_users?: Maybe<Users_Mutation_Response>;
   /** update single row of the table: "users" */
   update_users_by_pk?: Maybe<Users>;
+  /** update multiples rows of table: "users" */
+  update_users_many?: Maybe<Array<Maybe<Users_Mutation_Response>>>;
 };
 
-/** mutation root */
-export type Mutation_RootDelete_GroupsArgs = {
-  where: Groups_Bool_Exp;
-};
-
-/** mutation root */
-export type Mutation_RootDelete_Groups_By_PkArgs = {
-  id: Scalars['uuid'];
-};
-
-/** mutation root */
-export type Mutation_RootDelete_Profile_UsersArgs = {
-  where: Profile_Users_Bool_Exp;
-};
-
-/** mutation root */
-export type Mutation_RootDelete_Profile_Users_By_PkArgs = {
-  id: Scalars['uuid'];
-};
-
-/** mutation root */
-export type Mutation_RootDelete_ProfilesArgs = {
-  where: Profiles_Bool_Exp;
-};
-
-/** mutation root */
-export type Mutation_RootDelete_Profiles_By_PkArgs = {
-  id: Scalars['uuid'];
-};
 
 /** mutation root */
 export type Mutation_RootDelete_UsersArgs = {
   where: Users_Bool_Exp;
 };
 
+
 /** mutation root */
 export type Mutation_RootDelete_Users_By_PkArgs = {
-  id: Scalars['uuid'];
+  id: Scalars['uuid']['input'];
 };
 
-/** mutation root */
-export type Mutation_RootInsert_GroupsArgs = {
-  objects: Array<Groups_Insert_Input>;
-  on_conflict?: InputMaybe<Groups_On_Conflict>;
-};
-
-/** mutation root */
-export type Mutation_RootInsert_Groups_OneArgs = {
-  object: Groups_Insert_Input;
-  on_conflict?: InputMaybe<Groups_On_Conflict>;
-};
-
-/** mutation root */
-export type Mutation_RootInsert_Profile_UsersArgs = {
-  objects: Array<Profile_Users_Insert_Input>;
-  on_conflict?: InputMaybe<Profile_Users_On_Conflict>;
-};
-
-/** mutation root */
-export type Mutation_RootInsert_Profile_Users_OneArgs = {
-  object: Profile_Users_Insert_Input;
-  on_conflict?: InputMaybe<Profile_Users_On_Conflict>;
-};
-
-/** mutation root */
-export type Mutation_RootInsert_ProfilesArgs = {
-  objects: Array<Profiles_Insert_Input>;
-  on_conflict?: InputMaybe<Profiles_On_Conflict>;
-};
-
-/** mutation root */
-export type Mutation_RootInsert_Profiles_OneArgs = {
-  object: Profiles_Insert_Input;
-  on_conflict?: InputMaybe<Profiles_On_Conflict>;
-};
 
 /** mutation root */
 export type Mutation_RootInsert_UsersArgs = {
@@ -336,47 +94,13 @@ export type Mutation_RootInsert_UsersArgs = {
   on_conflict?: InputMaybe<Users_On_Conflict>;
 };
 
+
 /** mutation root */
 export type Mutation_RootInsert_Users_OneArgs = {
   object: Users_Insert_Input;
   on_conflict?: InputMaybe<Users_On_Conflict>;
 };
 
-/** mutation root */
-export type Mutation_RootUpdate_GroupsArgs = {
-  _set?: InputMaybe<Groups_Set_Input>;
-  where: Groups_Bool_Exp;
-};
-
-/** mutation root */
-export type Mutation_RootUpdate_Groups_By_PkArgs = {
-  _set?: InputMaybe<Groups_Set_Input>;
-  pk_columns: Groups_Pk_Columns_Input;
-};
-
-/** mutation root */
-export type Mutation_RootUpdate_Profile_UsersArgs = {
-  _set?: InputMaybe<Profile_Users_Set_Input>;
-  where: Profile_Users_Bool_Exp;
-};
-
-/** mutation root */
-export type Mutation_RootUpdate_Profile_Users_By_PkArgs = {
-  _set?: InputMaybe<Profile_Users_Set_Input>;
-  pk_columns: Profile_Users_Pk_Columns_Input;
-};
-
-/** mutation root */
-export type Mutation_RootUpdate_ProfilesArgs = {
-  _set?: InputMaybe<Profiles_Set_Input>;
-  where: Profiles_Bool_Exp;
-};
-
-/** mutation root */
-export type Mutation_RootUpdate_Profiles_By_PkArgs = {
-  _set?: InputMaybe<Profiles_Set_Input>;
-  pk_columns: Profiles_Pk_Columns_Input;
-};
 
 /** mutation root */
 export type Mutation_RootUpdate_UsersArgs = {
@@ -384,10 +108,17 @@ export type Mutation_RootUpdate_UsersArgs = {
   where: Users_Bool_Exp;
 };
 
+
 /** mutation root */
 export type Mutation_RootUpdate_Users_By_PkArgs = {
   _set?: InputMaybe<Users_Set_Input>;
   pk_columns: Users_Pk_Columns_Input;
+};
+
+
+/** mutation root */
+export type Mutation_RootUpdate_Users_ManyArgs = {
+  updates: Array<Users_Updates>;
 };
 
 /** column ordering options */
@@ -403,582 +134,103 @@ export enum Order_By {
   /** in descending order, nulls first */
   DescNullsFirst = 'desc_nulls_first',
   /** in descending order, nulls last */
-  DescNullsLast = 'desc_nulls_last',
-}
-
-/** columns and relationships of "profile_users" */
-export type Profile_Users = {
-  __typename?: 'profile_users';
-  id: Scalars['uuid'];
-  /** An object relationship */
-  profile: Profiles;
-  profile_id: Scalars['uuid'];
-  /** An object relationship */
-  user: Users;
-  user_id: Scalars['uuid'];
-};
-
-/** aggregated selection of "profile_users" */
-export type Profile_Users_Aggregate = {
-  __typename?: 'profile_users_aggregate';
-  aggregate?: Maybe<Profile_Users_Aggregate_Fields>;
-  nodes: Array<Profile_Users>;
-};
-
-/** aggregate fields of "profile_users" */
-export type Profile_Users_Aggregate_Fields = {
-  __typename?: 'profile_users_aggregate_fields';
-  count: Scalars['Int'];
-  max?: Maybe<Profile_Users_Max_Fields>;
-  min?: Maybe<Profile_Users_Min_Fields>;
-};
-
-/** aggregate fields of "profile_users" */
-export type Profile_Users_Aggregate_FieldsCountArgs = {
-  columns?: InputMaybe<Array<Profile_Users_Select_Column>>;
-  distinct?: InputMaybe<Scalars['Boolean']>;
-};
-
-/** order by aggregate values of table "profile_users" */
-export type Profile_Users_Aggregate_Order_By = {
-  count?: InputMaybe<Order_By>;
-  max?: InputMaybe<Profile_Users_Max_Order_By>;
-  min?: InputMaybe<Profile_Users_Min_Order_By>;
-};
-
-/** input type for inserting array relation for remote table "profile_users" */
-export type Profile_Users_Arr_Rel_Insert_Input = {
-  data: Array<Profile_Users_Insert_Input>;
-  /** on conflict condition */
-  on_conflict?: InputMaybe<Profile_Users_On_Conflict>;
-};
-
-/** Boolean expression to filter rows from the table "profile_users". All fields are combined with a logical 'AND'. */
-export type Profile_Users_Bool_Exp = {
-  _and?: InputMaybe<Array<Profile_Users_Bool_Exp>>;
-  _not?: InputMaybe<Profile_Users_Bool_Exp>;
-  _or?: InputMaybe<Array<Profile_Users_Bool_Exp>>;
-  id?: InputMaybe<Uuid_Comparison_Exp>;
-  profile?: InputMaybe<Profiles_Bool_Exp>;
-  profile_id?: InputMaybe<Uuid_Comparison_Exp>;
-  user?: InputMaybe<Users_Bool_Exp>;
-  user_id?: InputMaybe<Uuid_Comparison_Exp>;
-};
-
-/** unique or primary key constraints on table "profile_users" */
-export enum Profile_Users_Constraint {
-  /** unique or primary key constraint */
-  ProfileUsersPkey = 'profile_users_pkey',
-}
-
-/** input type for inserting data into table "profile_users" */
-export type Profile_Users_Insert_Input = {
-  id?: InputMaybe<Scalars['uuid']>;
-  profile?: InputMaybe<Profiles_Obj_Rel_Insert_Input>;
-  profile_id?: InputMaybe<Scalars['uuid']>;
-  user?: InputMaybe<Users_Obj_Rel_Insert_Input>;
-  user_id?: InputMaybe<Scalars['uuid']>;
-};
-
-/** aggregate max on columns */
-export type Profile_Users_Max_Fields = {
-  __typename?: 'profile_users_max_fields';
-  id?: Maybe<Scalars['uuid']>;
-  profile_id?: Maybe<Scalars['uuid']>;
-  user_id?: Maybe<Scalars['uuid']>;
-};
-
-/** order by max() on columns of table "profile_users" */
-export type Profile_Users_Max_Order_By = {
-  id?: InputMaybe<Order_By>;
-  profile_id?: InputMaybe<Order_By>;
-  user_id?: InputMaybe<Order_By>;
-};
-
-/** aggregate min on columns */
-export type Profile_Users_Min_Fields = {
-  __typename?: 'profile_users_min_fields';
-  id?: Maybe<Scalars['uuid']>;
-  profile_id?: Maybe<Scalars['uuid']>;
-  user_id?: Maybe<Scalars['uuid']>;
-};
-
-/** order by min() on columns of table "profile_users" */
-export type Profile_Users_Min_Order_By = {
-  id?: InputMaybe<Order_By>;
-  profile_id?: InputMaybe<Order_By>;
-  user_id?: InputMaybe<Order_By>;
-};
-
-/** response of any mutation on the table "profile_users" */
-export type Profile_Users_Mutation_Response = {
-  __typename?: 'profile_users_mutation_response';
-  /** number of rows affected by the mutation */
-  affected_rows: Scalars['Int'];
-  /** data from the rows affected by the mutation */
-  returning: Array<Profile_Users>;
-};
-
-/** on conflict condition type for table "profile_users" */
-export type Profile_Users_On_Conflict = {
-  constraint: Profile_Users_Constraint;
-  update_columns?: Array<Profile_Users_Update_Column>;
-  where?: InputMaybe<Profile_Users_Bool_Exp>;
-};
-
-/** Ordering options when selecting data from "profile_users". */
-export type Profile_Users_Order_By = {
-  id?: InputMaybe<Order_By>;
-  profile?: InputMaybe<Profiles_Order_By>;
-  profile_id?: InputMaybe<Order_By>;
-  user?: InputMaybe<Users_Order_By>;
-  user_id?: InputMaybe<Order_By>;
-};
-
-/** primary key columns input for table: profile_users */
-export type Profile_Users_Pk_Columns_Input = {
-  id: Scalars['uuid'];
-};
-
-/** select columns of table "profile_users" */
-export enum Profile_Users_Select_Column {
-  /** column name */
-  Id = 'id',
-  /** column name */
-  ProfileId = 'profile_id',
-  /** column name */
-  UserId = 'user_id',
-}
-
-/** input type for updating data in table "profile_users" */
-export type Profile_Users_Set_Input = {
-  id?: InputMaybe<Scalars['uuid']>;
-  profile_id?: InputMaybe<Scalars['uuid']>;
-  user_id?: InputMaybe<Scalars['uuid']>;
-};
-
-/** update columns of table "profile_users" */
-export enum Profile_Users_Update_Column {
-  /** column name */
-  Id = 'id',
-  /** column name */
-  ProfileId = 'profile_id',
-  /** column name */
-  UserId = 'user_id',
-}
-
-/** columns and relationships of "profiles" */
-export type Profiles = {
-  __typename?: 'profiles';
-  id: Scalars['uuid'];
-  nickname: Scalars['String'];
-  /** fetch data from the table: "profile_users" */
-  profile_users: Array<Profile_Users>;
-  /** An aggregate relationship */
-  profile_users_aggregate: Profile_Users_Aggregate;
-  /** An object relationship */
-  user?: Maybe<Users>;
-};
-
-/** columns and relationships of "profiles" */
-export type ProfilesProfile_UsersArgs = {
-  distinct_on?: InputMaybe<Array<Profile_Users_Select_Column>>;
-  limit?: InputMaybe<Scalars['Int']>;
-  offset?: InputMaybe<Scalars['Int']>;
-  order_by?: InputMaybe<Array<Profile_Users_Order_By>>;
-  where?: InputMaybe<Profile_Users_Bool_Exp>;
-};
-
-/** columns and relationships of "profiles" */
-export type ProfilesProfile_Users_AggregateArgs = {
-  distinct_on?: InputMaybe<Array<Profile_Users_Select_Column>>;
-  limit?: InputMaybe<Scalars['Int']>;
-  offset?: InputMaybe<Scalars['Int']>;
-  order_by?: InputMaybe<Array<Profile_Users_Order_By>>;
-  where?: InputMaybe<Profile_Users_Bool_Exp>;
-};
-
-/** aggregated selection of "profiles" */
-export type Profiles_Aggregate = {
-  __typename?: 'profiles_aggregate';
-  aggregate?: Maybe<Profiles_Aggregate_Fields>;
-  nodes: Array<Profiles>;
-};
-
-/** aggregate fields of "profiles" */
-export type Profiles_Aggregate_Fields = {
-  __typename?: 'profiles_aggregate_fields';
-  count: Scalars['Int'];
-  max?: Maybe<Profiles_Max_Fields>;
-  min?: Maybe<Profiles_Min_Fields>;
-};
-
-/** aggregate fields of "profiles" */
-export type Profiles_Aggregate_FieldsCountArgs = {
-  columns?: InputMaybe<Array<Profiles_Select_Column>>;
-  distinct?: InputMaybe<Scalars['Boolean']>;
-};
-
-/** Boolean expression to filter rows from the table "profiles". All fields are combined with a logical 'AND'. */
-export type Profiles_Bool_Exp = {
-  _and?: InputMaybe<Array<Profiles_Bool_Exp>>;
-  _not?: InputMaybe<Profiles_Bool_Exp>;
-  _or?: InputMaybe<Array<Profiles_Bool_Exp>>;
-  id?: InputMaybe<Uuid_Comparison_Exp>;
-  nickname?: InputMaybe<String_Comparison_Exp>;
-  profile_users?: InputMaybe<Profile_Users_Bool_Exp>;
-  user?: InputMaybe<Users_Bool_Exp>;
-};
-
-/** unique or primary key constraints on table "profiles" */
-export enum Profiles_Constraint {
-  /** unique or primary key constraint */
-  ProfilesPkey = 'profiles_pkey',
-}
-
-/** input type for inserting data into table "profiles" */
-export type Profiles_Insert_Input = {
-  id?: InputMaybe<Scalars['uuid']>;
-  nickname?: InputMaybe<Scalars['String']>;
-  profile_users?: InputMaybe<Profile_Users_Arr_Rel_Insert_Input>;
-  user?: InputMaybe<Users_Obj_Rel_Insert_Input>;
-};
-
-/** aggregate max on columns */
-export type Profiles_Max_Fields = {
-  __typename?: 'profiles_max_fields';
-  id?: Maybe<Scalars['uuid']>;
-  nickname?: Maybe<Scalars['String']>;
-};
-
-/** aggregate min on columns */
-export type Profiles_Min_Fields = {
-  __typename?: 'profiles_min_fields';
-  id?: Maybe<Scalars['uuid']>;
-  nickname?: Maybe<Scalars['String']>;
-};
-
-/** response of any mutation on the table "profiles" */
-export type Profiles_Mutation_Response = {
-  __typename?: 'profiles_mutation_response';
-  /** number of rows affected by the mutation */
-  affected_rows: Scalars['Int'];
-  /** data from the rows affected by the mutation */
-  returning: Array<Profiles>;
-};
-
-/** input type for inserting object relation for remote table "profiles" */
-export type Profiles_Obj_Rel_Insert_Input = {
-  data: Profiles_Insert_Input;
-  /** on conflict condition */
-  on_conflict?: InputMaybe<Profiles_On_Conflict>;
-};
-
-/** on conflict condition type for table "profiles" */
-export type Profiles_On_Conflict = {
-  constraint: Profiles_Constraint;
-  update_columns?: Array<Profiles_Update_Column>;
-  where?: InputMaybe<Profiles_Bool_Exp>;
-};
-
-/** Ordering options when selecting data from "profiles". */
-export type Profiles_Order_By = {
-  id?: InputMaybe<Order_By>;
-  nickname?: InputMaybe<Order_By>;
-  profile_users_aggregate?: InputMaybe<Profile_Users_Aggregate_Order_By>;
-  user?: InputMaybe<Users_Order_By>;
-};
-
-/** primary key columns input for table: profiles */
-export type Profiles_Pk_Columns_Input = {
-  id: Scalars['uuid'];
-};
-
-/** select columns of table "profiles" */
-export enum Profiles_Select_Column {
-  /** column name */
-  Id = 'id',
-  /** column name */
-  Nickname = 'nickname',
-}
-
-/** input type for updating data in table "profiles" */
-export type Profiles_Set_Input = {
-  id?: InputMaybe<Scalars['uuid']>;
-  nickname?: InputMaybe<Scalars['String']>;
-};
-
-/** update columns of table "profiles" */
-export enum Profiles_Update_Column {
-  /** column name */
-  Id = 'id',
-  /** column name */
-  Nickname = 'nickname',
+  DescNullsLast = 'desc_nulls_last'
 }
 
 export type Query_Root = {
   __typename?: 'query_root';
-  /** fetch data from the table: "groups" */
-  groups: Array<Groups>;
-  /** fetch aggregated fields from the table: "groups" */
-  groups_aggregate: Groups_Aggregate;
-  /** fetch data from the table: "groups" using primary key columns */
-  groups_by_pk?: Maybe<Groups>;
-  /** fetch data from the table: "profile_users" */
-  profile_users: Array<Profile_Users>;
-  /** An aggregate relationship */
-  profile_users_aggregate: Profile_Users_Aggregate;
-  /** fetch data from the table: "profile_users" using primary key columns */
-  profile_users_by_pk?: Maybe<Profile_Users>;
-  /** fetch data from the table: "profiles" */
-  profiles: Array<Profiles>;
-  /** fetch aggregated fields from the table: "profiles" */
-  profiles_aggregate: Profiles_Aggregate;
-  /** fetch data from the table: "profiles" using primary key columns */
-  profiles_by_pk?: Maybe<Profiles>;
-  /** An array relationship */
+  /** fetch data from the table: "users" */
   users: Array<Users>;
-  /** An aggregate relationship */
+  /** fetch aggregated fields from the table: "users" */
   users_aggregate: Users_Aggregate;
   /** fetch data from the table: "users" using primary key columns */
   users_by_pk?: Maybe<Users>;
 };
 
-export type Query_RootGroupsArgs = {
-  distinct_on?: InputMaybe<Array<Groups_Select_Column>>;
-  limit?: InputMaybe<Scalars['Int']>;
-  offset?: InputMaybe<Scalars['Int']>;
-  order_by?: InputMaybe<Array<Groups_Order_By>>;
-  where?: InputMaybe<Groups_Bool_Exp>;
-};
-
-export type Query_RootGroups_AggregateArgs = {
-  distinct_on?: InputMaybe<Array<Groups_Select_Column>>;
-  limit?: InputMaybe<Scalars['Int']>;
-  offset?: InputMaybe<Scalars['Int']>;
-  order_by?: InputMaybe<Array<Groups_Order_By>>;
-  where?: InputMaybe<Groups_Bool_Exp>;
-};
-
-export type Query_RootGroups_By_PkArgs = {
-  id: Scalars['uuid'];
-};
-
-export type Query_RootProfile_UsersArgs = {
-  distinct_on?: InputMaybe<Array<Profile_Users_Select_Column>>;
-  limit?: InputMaybe<Scalars['Int']>;
-  offset?: InputMaybe<Scalars['Int']>;
-  order_by?: InputMaybe<Array<Profile_Users_Order_By>>;
-  where?: InputMaybe<Profile_Users_Bool_Exp>;
-};
-
-export type Query_RootProfile_Users_AggregateArgs = {
-  distinct_on?: InputMaybe<Array<Profile_Users_Select_Column>>;
-  limit?: InputMaybe<Scalars['Int']>;
-  offset?: InputMaybe<Scalars['Int']>;
-  order_by?: InputMaybe<Array<Profile_Users_Order_By>>;
-  where?: InputMaybe<Profile_Users_Bool_Exp>;
-};
-
-export type Query_RootProfile_Users_By_PkArgs = {
-  id: Scalars['uuid'];
-};
-
-export type Query_RootProfilesArgs = {
-  distinct_on?: InputMaybe<Array<Profiles_Select_Column>>;
-  limit?: InputMaybe<Scalars['Int']>;
-  offset?: InputMaybe<Scalars['Int']>;
-  order_by?: InputMaybe<Array<Profiles_Order_By>>;
-  where?: InputMaybe<Profiles_Bool_Exp>;
-};
-
-export type Query_RootProfiles_AggregateArgs = {
-  distinct_on?: InputMaybe<Array<Profiles_Select_Column>>;
-  limit?: InputMaybe<Scalars['Int']>;
-  offset?: InputMaybe<Scalars['Int']>;
-  order_by?: InputMaybe<Array<Profiles_Order_By>>;
-  where?: InputMaybe<Profiles_Bool_Exp>;
-};
-
-export type Query_RootProfiles_By_PkArgs = {
-  id: Scalars['uuid'];
-};
 
 export type Query_RootUsersArgs = {
   distinct_on?: InputMaybe<Array<Users_Select_Column>>;
-  limit?: InputMaybe<Scalars['Int']>;
-  offset?: InputMaybe<Scalars['Int']>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
   order_by?: InputMaybe<Array<Users_Order_By>>;
   where?: InputMaybe<Users_Bool_Exp>;
 };
+
 
 export type Query_RootUsers_AggregateArgs = {
   distinct_on?: InputMaybe<Array<Users_Select_Column>>;
-  limit?: InputMaybe<Scalars['Int']>;
-  offset?: InputMaybe<Scalars['Int']>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
   order_by?: InputMaybe<Array<Users_Order_By>>;
   where?: InputMaybe<Users_Bool_Exp>;
 };
 
+
 export type Query_RootUsers_By_PkArgs = {
-  id: Scalars['uuid'];
+  id: Scalars['uuid']['input'];
 };
 
 export type Subscription_Root = {
   __typename?: 'subscription_root';
-  /** fetch data from the table: "groups" */
-  groups: Array<Groups>;
-  /** fetch aggregated fields from the table: "groups" */
-  groups_aggregate: Groups_Aggregate;
-  /** fetch data from the table: "groups" using primary key columns */
-  groups_by_pk?: Maybe<Groups>;
-  /** fetch data from the table: "profile_users" */
-  profile_users: Array<Profile_Users>;
-  /** An aggregate relationship */
-  profile_users_aggregate: Profile_Users_Aggregate;
-  /** fetch data from the table: "profile_users" using primary key columns */
-  profile_users_by_pk?: Maybe<Profile_Users>;
-  /** fetch data from the table: "profiles" */
-  profiles: Array<Profiles>;
-  /** fetch aggregated fields from the table: "profiles" */
-  profiles_aggregate: Profiles_Aggregate;
-  /** fetch data from the table: "profiles" using primary key columns */
-  profiles_by_pk?: Maybe<Profiles>;
-  /** An array relationship */
+  /** fetch data from the table: "users" */
   users: Array<Users>;
-  /** An aggregate relationship */
+  /** fetch aggregated fields from the table: "users" */
   users_aggregate: Users_Aggregate;
   /** fetch data from the table: "users" using primary key columns */
   users_by_pk?: Maybe<Users>;
+  /** fetch data from the table in a streaming manner: "users" */
+  users_stream: Array<Users>;
 };
 
-export type Subscription_RootGroupsArgs = {
-  distinct_on?: InputMaybe<Array<Groups_Select_Column>>;
-  limit?: InputMaybe<Scalars['Int']>;
-  offset?: InputMaybe<Scalars['Int']>;
-  order_by?: InputMaybe<Array<Groups_Order_By>>;
-  where?: InputMaybe<Groups_Bool_Exp>;
-};
-
-export type Subscription_RootGroups_AggregateArgs = {
-  distinct_on?: InputMaybe<Array<Groups_Select_Column>>;
-  limit?: InputMaybe<Scalars['Int']>;
-  offset?: InputMaybe<Scalars['Int']>;
-  order_by?: InputMaybe<Array<Groups_Order_By>>;
-  where?: InputMaybe<Groups_Bool_Exp>;
-};
-
-export type Subscription_RootGroups_By_PkArgs = {
-  id: Scalars['uuid'];
-};
-
-export type Subscription_RootProfile_UsersArgs = {
-  distinct_on?: InputMaybe<Array<Profile_Users_Select_Column>>;
-  limit?: InputMaybe<Scalars['Int']>;
-  offset?: InputMaybe<Scalars['Int']>;
-  order_by?: InputMaybe<Array<Profile_Users_Order_By>>;
-  where?: InputMaybe<Profile_Users_Bool_Exp>;
-};
-
-export type Subscription_RootProfile_Users_AggregateArgs = {
-  distinct_on?: InputMaybe<Array<Profile_Users_Select_Column>>;
-  limit?: InputMaybe<Scalars['Int']>;
-  offset?: InputMaybe<Scalars['Int']>;
-  order_by?: InputMaybe<Array<Profile_Users_Order_By>>;
-  where?: InputMaybe<Profile_Users_Bool_Exp>;
-};
-
-export type Subscription_RootProfile_Users_By_PkArgs = {
-  id: Scalars['uuid'];
-};
-
-export type Subscription_RootProfilesArgs = {
-  distinct_on?: InputMaybe<Array<Profiles_Select_Column>>;
-  limit?: InputMaybe<Scalars['Int']>;
-  offset?: InputMaybe<Scalars['Int']>;
-  order_by?: InputMaybe<Array<Profiles_Order_By>>;
-  where?: InputMaybe<Profiles_Bool_Exp>;
-};
-
-export type Subscription_RootProfiles_AggregateArgs = {
-  distinct_on?: InputMaybe<Array<Profiles_Select_Column>>;
-  limit?: InputMaybe<Scalars['Int']>;
-  offset?: InputMaybe<Scalars['Int']>;
-  order_by?: InputMaybe<Array<Profiles_Order_By>>;
-  where?: InputMaybe<Profiles_Bool_Exp>;
-};
-
-export type Subscription_RootProfiles_By_PkArgs = {
-  id: Scalars['uuid'];
-};
 
 export type Subscription_RootUsersArgs = {
   distinct_on?: InputMaybe<Array<Users_Select_Column>>;
-  limit?: InputMaybe<Scalars['Int']>;
-  offset?: InputMaybe<Scalars['Int']>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
   order_by?: InputMaybe<Array<Users_Order_By>>;
   where?: InputMaybe<Users_Bool_Exp>;
 };
+
 
 export type Subscription_RootUsers_AggregateArgs = {
   distinct_on?: InputMaybe<Array<Users_Select_Column>>;
-  limit?: InputMaybe<Scalars['Int']>;
-  offset?: InputMaybe<Scalars['Int']>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
   order_by?: InputMaybe<Array<Users_Order_By>>;
   where?: InputMaybe<Users_Bool_Exp>;
 };
 
+
 export type Subscription_RootUsers_By_PkArgs = {
-  id: Scalars['uuid'];
+  id: Scalars['uuid']['input'];
+};
+
+
+export type Subscription_RootUsers_StreamArgs = {
+  batch_size: Scalars['Int']['input'];
+  cursor: Array<InputMaybe<Users_Stream_Cursor_Input>>;
+  where?: InputMaybe<Users_Bool_Exp>;
 };
 
 /** Boolean expression to compare columns of type "timestamptz". All fields are combined with logical 'AND'. */
 export type Timestamptz_Comparison_Exp = {
-  _eq?: InputMaybe<Scalars['timestamptz']>;
-  _gt?: InputMaybe<Scalars['timestamptz']>;
-  _gte?: InputMaybe<Scalars['timestamptz']>;
-  _in?: InputMaybe<Array<Scalars['timestamptz']>>;
-  _is_null?: InputMaybe<Scalars['Boolean']>;
-  _lt?: InputMaybe<Scalars['timestamptz']>;
-  _lte?: InputMaybe<Scalars['timestamptz']>;
-  _neq?: InputMaybe<Scalars['timestamptz']>;
-  _nin?: InputMaybe<Array<Scalars['timestamptz']>>;
+  _eq?: InputMaybe<Scalars['timestamptz']['input']>;
+  _gt?: InputMaybe<Scalars['timestamptz']['input']>;
+  _gte?: InputMaybe<Scalars['timestamptz']['input']>;
+  _in?: InputMaybe<Array<Scalars['timestamptz']['input']>>;
+  _is_null?: InputMaybe<Scalars['Boolean']['input']>;
+  _lt?: InputMaybe<Scalars['timestamptz']['input']>;
+  _lte?: InputMaybe<Scalars['timestamptz']['input']>;
+  _neq?: InputMaybe<Scalars['timestamptz']['input']>;
+  _nin?: InputMaybe<Array<Scalars['timestamptz']['input']>>;
 };
 
 /** columns and relationships of "users" */
 export type Users = {
   __typename?: 'users';
-  created_at: Scalars['timestamptz'];
-  /** An object relationship */
-  group?: Maybe<Groups>;
-  group_id?: Maybe<Scalars['uuid']>;
-  id: Scalars['uuid'];
-  name: Scalars['String'];
-  /** An object relationship */
-  profile?: Maybe<Profiles>;
-  profile_id?: Maybe<Scalars['uuid']>;
-  /** fetch data from the table: "profile_users" */
-  profile_users: Array<Profile_Users>;
-  /** An aggregate relationship */
-  profile_users_aggregate: Profile_Users_Aggregate;
-};
-
-/** columns and relationships of "users" */
-export type UsersProfile_UsersArgs = {
-  distinct_on?: InputMaybe<Array<Profile_Users_Select_Column>>;
-  limit?: InputMaybe<Scalars['Int']>;
-  offset?: InputMaybe<Scalars['Int']>;
-  order_by?: InputMaybe<Array<Profile_Users_Order_By>>;
-  where?: InputMaybe<Profile_Users_Bool_Exp>;
-};
-
-/** columns and relationships of "users" */
-export type UsersProfile_Users_AggregateArgs = {
-  distinct_on?: InputMaybe<Array<Profile_Users_Select_Column>>;
-  limit?: InputMaybe<Scalars['Int']>;
-  offset?: InputMaybe<Scalars['Int']>;
-  order_by?: InputMaybe<Array<Profile_Users_Order_By>>;
-  where?: InputMaybe<Profile_Users_Bool_Exp>;
+  created_at: Scalars['timestamptz']['output'];
+  id: Scalars['uuid']['output'];
+  name: Scalars['String']['output'];
 };
 
 /** aggregated selection of "users" */
@@ -991,29 +243,16 @@ export type Users_Aggregate = {
 /** aggregate fields of "users" */
 export type Users_Aggregate_Fields = {
   __typename?: 'users_aggregate_fields';
-  count: Scalars['Int'];
+  count: Scalars['Int']['output'];
   max?: Maybe<Users_Max_Fields>;
   min?: Maybe<Users_Min_Fields>;
 };
 
+
 /** aggregate fields of "users" */
 export type Users_Aggregate_FieldsCountArgs = {
   columns?: InputMaybe<Array<Users_Select_Column>>;
-  distinct?: InputMaybe<Scalars['Boolean']>;
-};
-
-/** order by aggregate values of table "users" */
-export type Users_Aggregate_Order_By = {
-  count?: InputMaybe<Order_By>;
-  max?: InputMaybe<Users_Max_Order_By>;
-  min?: InputMaybe<Users_Min_Order_By>;
-};
-
-/** input type for inserting array relation for remote table "users" */
-export type Users_Arr_Rel_Insert_Input = {
-  data: Array<Users_Insert_Input>;
-  /** on conflict condition */
-  on_conflict?: InputMaybe<Users_On_Conflict>;
+  distinct?: InputMaybe<Scalars['Boolean']['input']>;
 };
 
 /** Boolean expression to filter rows from the table "users". All fields are combined with a logical 'AND'. */
@@ -1022,90 +261,49 @@ export type Users_Bool_Exp = {
   _not?: InputMaybe<Users_Bool_Exp>;
   _or?: InputMaybe<Array<Users_Bool_Exp>>;
   created_at?: InputMaybe<Timestamptz_Comparison_Exp>;
-  group?: InputMaybe<Groups_Bool_Exp>;
-  group_id?: InputMaybe<Uuid_Comparison_Exp>;
   id?: InputMaybe<Uuid_Comparison_Exp>;
   name?: InputMaybe<String_Comparison_Exp>;
-  profile?: InputMaybe<Profiles_Bool_Exp>;
-  profile_id?: InputMaybe<Uuid_Comparison_Exp>;
-  profile_users?: InputMaybe<Profile_Users_Bool_Exp>;
 };
 
 /** unique or primary key constraints on table "users" */
 export enum Users_Constraint {
-  /** unique or primary key constraint */
-  UsersPkey = 'users_pkey',
-  /** unique or primary key constraint */
-  UsersProfileIdKey = 'users_profile_id_key',
+  /** unique or primary key constraint on columns "id" */
+  UsersPkey = 'users_pkey'
 }
 
 /** input type for inserting data into table "users" */
 export type Users_Insert_Input = {
-  created_at?: InputMaybe<Scalars['timestamptz']>;
-  group?: InputMaybe<Groups_Obj_Rel_Insert_Input>;
-  group_id?: InputMaybe<Scalars['uuid']>;
-  id?: InputMaybe<Scalars['uuid']>;
-  name?: InputMaybe<Scalars['String']>;
-  profile?: InputMaybe<Profiles_Obj_Rel_Insert_Input>;
-  profile_id?: InputMaybe<Scalars['uuid']>;
-  profile_users?: InputMaybe<Profile_Users_Arr_Rel_Insert_Input>;
+  created_at?: InputMaybe<Scalars['timestamptz']['input']>;
+  id?: InputMaybe<Scalars['uuid']['input']>;
+  name?: InputMaybe<Scalars['String']['input']>;
 };
 
 /** aggregate max on columns */
 export type Users_Max_Fields = {
   __typename?: 'users_max_fields';
-  created_at?: Maybe<Scalars['timestamptz']>;
-  group_id?: Maybe<Scalars['uuid']>;
-  id?: Maybe<Scalars['uuid']>;
-  name?: Maybe<Scalars['String']>;
-  profile_id?: Maybe<Scalars['uuid']>;
-};
-
-/** order by max() on columns of table "users" */
-export type Users_Max_Order_By = {
-  created_at?: InputMaybe<Order_By>;
-  group_id?: InputMaybe<Order_By>;
-  id?: InputMaybe<Order_By>;
-  name?: InputMaybe<Order_By>;
-  profile_id?: InputMaybe<Order_By>;
+  created_at?: Maybe<Scalars['timestamptz']['output']>;
+  id?: Maybe<Scalars['uuid']['output']>;
+  name?: Maybe<Scalars['String']['output']>;
 };
 
 /** aggregate min on columns */
 export type Users_Min_Fields = {
   __typename?: 'users_min_fields';
-  created_at?: Maybe<Scalars['timestamptz']>;
-  group_id?: Maybe<Scalars['uuid']>;
-  id?: Maybe<Scalars['uuid']>;
-  name?: Maybe<Scalars['String']>;
-  profile_id?: Maybe<Scalars['uuid']>;
-};
-
-/** order by min() on columns of table "users" */
-export type Users_Min_Order_By = {
-  created_at?: InputMaybe<Order_By>;
-  group_id?: InputMaybe<Order_By>;
-  id?: InputMaybe<Order_By>;
-  name?: InputMaybe<Order_By>;
-  profile_id?: InputMaybe<Order_By>;
+  created_at?: Maybe<Scalars['timestamptz']['output']>;
+  id?: Maybe<Scalars['uuid']['output']>;
+  name?: Maybe<Scalars['String']['output']>;
 };
 
 /** response of any mutation on the table "users" */
 export type Users_Mutation_Response = {
   __typename?: 'users_mutation_response';
   /** number of rows affected by the mutation */
-  affected_rows: Scalars['Int'];
+  affected_rows: Scalars['Int']['output'];
   /** data from the rows affected by the mutation */
   returning: Array<Users>;
 };
 
-/** input type for inserting object relation for remote table "users" */
-export type Users_Obj_Rel_Insert_Input = {
-  data: Users_Insert_Input;
-  /** on conflict condition */
-  on_conflict?: InputMaybe<Users_On_Conflict>;
-};
-
-/** on conflict condition type for table "users" */
+/** on_conflict condition type for table "users" */
 export type Users_On_Conflict = {
   constraint: Users_Constraint;
   update_columns?: Array<Users_Update_Column>;
@@ -1115,18 +313,13 @@ export type Users_On_Conflict = {
 /** Ordering options when selecting data from "users". */
 export type Users_Order_By = {
   created_at?: InputMaybe<Order_By>;
-  group?: InputMaybe<Groups_Order_By>;
-  group_id?: InputMaybe<Order_By>;
   id?: InputMaybe<Order_By>;
   name?: InputMaybe<Order_By>;
-  profile?: InputMaybe<Profiles_Order_By>;
-  profile_id?: InputMaybe<Order_By>;
-  profile_users_aggregate?: InputMaybe<Profile_Users_Aggregate_Order_By>;
 };
 
 /** primary key columns input for table: users */
 export type Users_Pk_Columns_Input = {
-  id: Scalars['uuid'];
+  id: Scalars['uuid']['input'];
 };
 
 /** select columns of table "users" */
@@ -1134,22 +327,31 @@ export enum Users_Select_Column {
   /** column name */
   CreatedAt = 'created_at',
   /** column name */
-  GroupId = 'group_id',
-  /** column name */
   Id = 'id',
   /** column name */
-  Name = 'name',
-  /** column name */
-  ProfileId = 'profile_id',
+  Name = 'name'
 }
 
 /** input type for updating data in table "users" */
 export type Users_Set_Input = {
-  created_at?: InputMaybe<Scalars['timestamptz']>;
-  group_id?: InputMaybe<Scalars['uuid']>;
-  id?: InputMaybe<Scalars['uuid']>;
-  name?: InputMaybe<Scalars['String']>;
-  profile_id?: InputMaybe<Scalars['uuid']>;
+  created_at?: InputMaybe<Scalars['timestamptz']['input']>;
+  id?: InputMaybe<Scalars['uuid']['input']>;
+  name?: InputMaybe<Scalars['String']['input']>;
+};
+
+/** Streaming cursor of the table "users" */
+export type Users_Stream_Cursor_Input = {
+  /** Stream column input with initial value */
+  initial_value: Users_Stream_Cursor_Value_Input;
+  /** cursor ordering */
+  ordering?: InputMaybe<Cursor_Ordering>;
+};
+
+/** Initial value of the column from where the streaming should start */
+export type Users_Stream_Cursor_Value_Input = {
+  created_at?: InputMaybe<Scalars['timestamptz']['input']>;
+  id?: InputMaybe<Scalars['uuid']['input']>;
+  name?: InputMaybe<Scalars['String']['input']>;
 };
 
 /** update columns of table "users" */
@@ -1157,360 +359,71 @@ export enum Users_Update_Column {
   /** column name */
   CreatedAt = 'created_at',
   /** column name */
-  GroupId = 'group_id',
-  /** column name */
   Id = 'id',
   /** column name */
-  Name = 'name',
-  /** column name */
-  ProfileId = 'profile_id',
+  Name = 'name'
 }
+
+export type Users_Updates = {
+  /** sets the columns of the filtered rows to the given values */
+  _set?: InputMaybe<Users_Set_Input>;
+  /** filter the rows which have to be updated */
+  where: Users_Bool_Exp;
+};
 
 /** Boolean expression to compare columns of type "uuid". All fields are combined with logical 'AND'. */
 export type Uuid_Comparison_Exp = {
-  _eq?: InputMaybe<Scalars['uuid']>;
-  _gt?: InputMaybe<Scalars['uuid']>;
-  _gte?: InputMaybe<Scalars['uuid']>;
-  _in?: InputMaybe<Array<Scalars['uuid']>>;
-  _is_null?: InputMaybe<Scalars['Boolean']>;
-  _lt?: InputMaybe<Scalars['uuid']>;
-  _lte?: InputMaybe<Scalars['uuid']>;
-  _neq?: InputMaybe<Scalars['uuid']>;
-  _nin?: InputMaybe<Array<Scalars['uuid']>>;
+  _eq?: InputMaybe<Scalars['uuid']['input']>;
+  _gt?: InputMaybe<Scalars['uuid']['input']>;
+  _gte?: InputMaybe<Scalars['uuid']['input']>;
+  _in?: InputMaybe<Array<Scalars['uuid']['input']>>;
+  _is_null?: InputMaybe<Scalars['Boolean']['input']>;
+  _lt?: InputMaybe<Scalars['uuid']['input']>;
+  _lte?: InputMaybe<Scalars['uuid']['input']>;
+  _neq?: InputMaybe<Scalars['uuid']['input']>;
+  _nin?: InputMaybe<Array<Scalars['uuid']['input']>>;
 };
 
-export type GetUsersQueryVariables = Exact<{ [key: string]: never }>;
+export type GetUsersQueryVariables = Exact<{ [key: string]: never; }>;
 
-export type GetUsersQuery = {
-  __typename?: 'query_root';
-  users: Array<{
-    __typename?: 'users';
-    id: any;
-    name: string;
-    created_at: any;
-  }>;
-};
 
-export type GetUserIdsQueryVariables = Exact<{ [key: string]: never }>;
+export type GetUsersQuery = { users: Array<{ id: string, name: string, created_at: string }> };
 
-export type GetUserIdsQuery = {
-  __typename?: 'query_root';
-  users: Array<{ __typename?: 'users'; id: any }>;
-};
+export type GetUsersLocalQueryVariables = Exact<{ [key: string]: never; }>;
+
+
+export type GetUsersLocalQuery = { users: Array<{ id: string, name: string, created_at: string }> };
+
+export type GetUserIdsQueryVariables = Exact<{ [key: string]: never; }>;
+
+
+export type GetUserIdsQuery = { users: Array<{ id: string }> };
 
 export type GetUserByIdQueryVariables = Exact<{
-  id: Scalars['uuid'];
+  id: string;
 }>;
 
-export type GetUserByIdQuery = {
-  __typename?: 'query_root';
-  users_by_pk?:
-    | { __typename?: 'users'; id: any; name: string; created_at: any }
-    | null
-    | undefined;
-};
+
+export type GetUserByIdQuery = { users_by_pk: { id: string, name: string, created_at: string } | null };
 
 export type CreateUserMutationVariables = Exact<{
-  name: Scalars['String'];
+  name: string;
 }>;
 
-export type CreateUserMutation = {
-  __typename?: 'mutation_root';
-  insert_users_one?:
-    | { __typename?: 'users'; id: any; name: string; created_at: any }
-    | null
-    | undefined;
-};
+
+export type CreateUserMutation = { insert_users_one: { id: string, name: string, created_at: string } | null };
 
 export type DeleteUserMutationVariables = Exact<{
-  id: Scalars['uuid'];
+  id: string;
 }>;
 
-export type DeleteUserMutation = {
-  __typename?: 'mutation_root';
-  delete_users_by_pk?:
-    | { __typename?: 'users'; id: any; name: string; created_at: any }
-    | null
-    | undefined;
-};
+
+export type DeleteUserMutation = { delete_users_by_pk: { id: string, name: string, created_at: string } | null };
 
 export type UpdateUserMutationVariables = Exact<{
-  id: Scalars['uuid'];
-  name: Scalars['String'];
+  id: string;
+  name: string;
 }>;
 
-export type UpdateUserMutation = {
-  __typename?: 'mutation_root';
-  update_users_by_pk?:
-    | { __typename?: 'users'; id: any; name: string; created_at: any }
-    | null
-    | undefined;
-};
 
-export const GetUsersDocument = gql`
-  query GetUsers {
-    users(order_by: { created_at: desc }) {
-      id
-      name
-      created_at
-    }
-  }
-`;
-
-/**
- * __useGetUsersQuery__
- *
- * To run a query within a React component, call `useGetUsersQuery` and pass it any options that fit your needs.
- * When your component renders, `useGetUsersQuery` returns an object from Apollo Client that contains loading, error, and data properties
- * you can use to render your UI.
- *
- * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
- *
- * @example
- * const { data, loading, error } = useGetUsersQuery({
- *   variables: {
- *   },
- * });
- */
-export function useGetUsersQuery(baseOptions?: any) {
-  const options = { ...defaultOptions, ...baseOptions };
-  return useQuery<GetUsersQuery, GetUsersQueryVariables>(
-    GetUsersDocument,
-    options
-  );
-}
-export function useGetUsersLazyQuery(baseOptions?: any) {
-  const options = { ...defaultOptions, ...baseOptions };
-  return useLazyQuery<GetUsersQuery, GetUsersQueryVariables>(
-    GetUsersDocument,
-    options
-  );
-}
-export type GetUsersQueryHookResult = ReturnType<typeof useGetUsersQuery>;
-export type GetUsersLazyQueryHookResult = ReturnType<
-  typeof useGetUsersLazyQuery
->;
-export type GetUsersQueryResult = any;
-export const GetUserIdsDocument = gql`
-  query GetUserIds {
-    users(order_by: { created_at: desc }) {
-      id
-    }
-  }
-`;
-
-/**
- * __useGetUserIdsQuery__
- *
- * To run a query within a React component, call `useGetUserIdsQuery` and pass it any options that fit your needs.
- * When your component renders, `useGetUserIdsQuery` returns an object from Apollo Client that contains loading, error, and data properties
- * you can use to render your UI.
- *
- * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
- *
- * @example
- * const { data, loading, error } = useGetUserIdsQuery({
- *   variables: {
- *   },
- * });
- */
-export function useGetUserIdsQuery(baseOptions?: any) {
-  const options = { ...defaultOptions, ...baseOptions };
-  return useQuery<GetUserIdsQuery, GetUserIdsQueryVariables>(
-    GetUserIdsDocument,
-    options
-  );
-}
-export function useGetUserIdsLazyQuery(baseOptions?: any) {
-  const options = { ...defaultOptions, ...baseOptions };
-  return useLazyQuery<GetUserIdsQuery, GetUserIdsQueryVariables>(
-    GetUserIdsDocument,
-    options
-  );
-}
-export type GetUserIdsQueryHookResult = ReturnType<typeof useGetUserIdsQuery>;
-export type GetUserIdsLazyQueryHookResult = ReturnType<
-  typeof useGetUserIdsLazyQuery
->;
-export type GetUserIdsQueryResult = any;
-export const GetUserByIdDocument = gql`
-  query GetUserById($id: uuid!) {
-    users_by_pk(id: $id) {
-      id
-      name
-      created_at
-    }
-  }
-`;
-
-/**
- * __useGetUserByIdQuery__
- *
- * To run a query within a React component, call `useGetUserByIdQuery` and pass it any options that fit your needs.
- * When your component renders, `useGetUserByIdQuery` returns an object from Apollo Client that contains loading, error, and data properties
- * you can use to render your UI.
- *
- * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
- *
- * @example
- * const { data, loading, error } = useGetUserByIdQuery({
- *   variables: {
- *      id: // value for 'id'
- *   },
- * });
- */
-export function useGetUserByIdQuery(baseOptions: any) {
-  const options = { ...defaultOptions, ...baseOptions };
-  return useQuery<GetUserByIdQuery, GetUserByIdQueryVariables>(
-    GetUserByIdDocument,
-    options
-  );
-}
-export function useGetUserByIdLazyQuery(baseOptions?: any) {
-  const options = { ...defaultOptions, ...baseOptions };
-  return useLazyQuery<GetUserByIdQuery, GetUserByIdQueryVariables>(
-    GetUserByIdDocument,
-    options
-  );
-}
-export type GetUserByIdQueryHookResult = ReturnType<typeof useGetUserByIdQuery>;
-export type GetUserByIdLazyQueryHookResult = ReturnType<
-  typeof useGetUserByIdLazyQuery
->;
-export type GetUserByIdQueryResult = any;
-export const CreateUserDocument = gql`
-  mutation CreateUser($name: String!) {
-    insert_users_one(object: { name: $name }) {
-      id
-      name
-      created_at
-    }
-  }
-`;
-export type CreateUserMutationFn = any;
-
-/**
- * __useCreateUserMutation__
- *
- * To run a mutation, you first call `useCreateUserMutation` within a React component and pass it any options that fit your needs.
- * When your component renders, `useCreateUserMutation` returns a tuple that includes:
- * - A mutate function that you can call at any time to execute the mutation
- * - An object with fields that represent the current status of the mutation's execution
- *
- * @param baseOptions options that will be passed into the mutation, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options-2;
- *
- * @example
- * const [createUserMutation, { data, loading, error }] = useCreateUserMutation({
- *   variables: {
- *      name: // value for 'name'
- *   },
- * });
- */
-export function useCreateUserMutation(
-  baseOptions?: Apollo.MutationOptions<
-    CreateUserMutation,
-    CreateUserMutationVariables
-  >
-) {
-  const options = { ...defaultOptions, ...baseOptions };
-  return useMutation<CreateUserMutation, CreateUserMutationVariables>(
-    CreateUserDocument,
-    options
-  );
-}
-export type CreateUserMutationHookResult = ReturnType<
-  typeof useCreateUserMutation
->;
-export type CreateUserMutationResult = any;
-export type CreateUserMutationOptions = any;
-export const DeleteUserDocument = gql`
-  mutation DeleteUser($id: uuid!) {
-    delete_users_by_pk(id: $id) {
-      id
-      name
-      created_at
-    }
-  }
-`;
-export type DeleteUserMutationFn = any;
-
-/**
- * __useDeleteUserMutation__
- *
- * To run a mutation, you first call `useDeleteUserMutation` within a React component and pass it any options that fit your needs.
- * When your component renders, `useDeleteUserMutation` returns a tuple that includes:
- * - A mutate function that you can call at any time to execute the mutation
- * - An object with fields that represent the current status of the mutation's execution
- *
- * @param baseOptions options that will be passed into the mutation, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options-2;
- *
- * @example
- * const [deleteUserMutation, { data, loading, error }] = useDeleteUserMutation({
- *   variables: {
- *      id: // value for 'id'
- *   },
- * });
- */
-export function useDeleteUserMutation(
-  baseOptions?: Apollo.MutationOptions<
-    DeleteUserMutation,
-    DeleteUserMutationVariables
-  >
-) {
-  const options = { ...defaultOptions, ...baseOptions };
-  return useMutation<DeleteUserMutation, DeleteUserMutationVariables>(
-    DeleteUserDocument,
-    options
-  );
-}
-export type DeleteUserMutationHookResult = ReturnType<
-  typeof useDeleteUserMutation
->;
-export type DeleteUserMutationResult = any;
-export type DeleteUserMutationOptions = any;
-export const UpdateUserDocument = gql`
-  mutation UpdateUser($id: uuid!, $name: String!) {
-    update_users_by_pk(pk_columns: { id: $id }, _set: { name: $name }) {
-      id
-      name
-      created_at
-    }
-  }
-`;
-export type UpdateUserMutationFn = any;
-
-/**
- * __useUpdateUserMutation__
- *
- * To run a mutation, you first call `useUpdateUserMutation` within a React component and pass it any options that fit your needs.
- * When your component renders, `useUpdateUserMutation` returns a tuple that includes:
- * - A mutate function that you can call at any time to execute the mutation
- * - An object with fields that represent the current status of the mutation's execution
- *
- * @param baseOptions options that will be passed into the mutation, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options-2;
- *
- * @example
- * const [updateUserMutation, { data, loading, error }] = useUpdateUserMutation({
- *   variables: {
- *      id: // value for 'id'
- *      name: // value for 'name'
- *   },
- * });
- */
-export function useUpdateUserMutation(
-  baseOptions?: Apollo.MutationOptions<
-    UpdateUserMutation,
-    UpdateUserMutationVariables
-  >
-) {
-  const options = { ...defaultOptions, ...baseOptions };
-  return useMutation<UpdateUserMutation, UpdateUserMutationVariables>(
-    UpdateUserDocument,
-    options
-  );
-}
-export type UpdateUserMutationHookResult = ReturnType<
-  typeof useUpdateUserMutation
->;
-export type UpdateUserMutationResult = any;
-export type UpdateUserMutationOptions = any;
+export type UpdateUserMutation = { update_users_by_pk: { id: string, name: string, created_at: string } | null };


### PR DESCRIPTION
## 背景・問題

`pnpm gen-types` の出力 `types/generated/graphql.tsx` が `@apollo/client@4` 下で **tsc 16 エラー**。`@graphql-codegen/typescript-react-apollo`（最新 4.4.2、Apollo v4 未対応）が v3 API（`Apollo.useMutation` / `MutationFunction` / `MutationResult` / `BaseMutationOptions` / `MutationHookOptions`）を出力するため。コミット済みファイルは手動で `any` 化したハックで、再生成すると毎回壊れる状態だった。

## 原因と方針

調査の結果、**生成される React-Apollo フック・`*Document` は consumer から一切使われていない dead code**（consumer は生成「型」のみ使用、生成フック使用箇所 0）。よって最小・恒久解として `typescript-react-apollo` プラグインを除去し、`typescript` + `typescript-operations` の**型生成のみ**に変更。Apollo 結合を完全に排し、`pnpm gen-types` を冪等化。

## 変更内容

- `codegen.yml`: `typescript-react-apollo` プラグインと関連 config を除去（型生成のみ）
- `package.json` / `pnpm-lock.yaml`: 未使用化した `@graphql-codegen/typescript-react-apollo` を削除
- `types/generated/graphql.tsx`: 再生成（Apollo 結合排除・純粋な型のみ）
- `components/UserItem.tsx`: 除去された `DeleteUserMutationFn`（旧 `any`）を Apollo v4 の `MutationTuple<DeleteUserMutation, DeleteUserMutationVariables>[0]` 型へ適合
- `pages/hasura-crud.tsx`: `useMutation` に Variables 総称を明示し型安全性を改善

## 検証

- `pnpm exec tsc --noEmit`: **0 エラー**（修正前 16）
- `pnpm exec vitest run`: **6/6 PASS**
- `pnpm gen-types` 2 回実行で出力 md5 一致＝**冪等**（手動パッチ不要）

代替案（import 再マッピング config / プラグイン版上げ / client-preset 移行）はいずれも非互換解消不可・最大影響のため不採用。本変更が最小ブラスト半径かつ非対症療法。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated internal type definitions for mutation operations to use standardized patterns
  * Revised GraphQL type handling across related components

* **Chores**
  * Updated GraphQL code generation dependencies and configuration for improved tooling compatibility

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kakikubo/learning-hasura/pull/1790?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->